### PR TITLE
docs(cli): add v0.14.1 and v0.14.2 release notes

### DIFF
--- a/docs/en/docs/changelog.md
+++ b/docs/en/docs/changelog.md
@@ -5,7 +5,18 @@ slug: changelog
 sidebar_position: 7
 ---
 
+## 2026-04-08
+
+### CLI v0.14.2
+
+- **`--lang` flag** — set content language (`zh-CN`, `zh-HK`, `en`) for all commands; falls back to system `LANG` env var
+
 ## 2026-04-02
+
+### CLI v0.14.1
+
+- **CN region login** — `longbridge login` now supports China region routing
+- **`-v` flag** — quick version check
 
 ### CLI v0.14.0
 

--- a/docs/en/docs/cli.md
+++ b/docs/en/docs/cli.md
@@ -358,6 +358,15 @@ Longbridge OpenAPI: maximum 10 calls per second. The SDK auto-refreshes OAuth to
 
 ## Release notes
 
+### [v0.14.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.14.2)
+
+- **New: `--lang` global flag** — set content language (`zh-CN`, `zh-HK`, `en`) for all commands; falls back to system `LANG` env var then `en`
+
+### [v0.14.1](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.14.1)
+
+- **New: CN region login** — `longbridge login` now supports China region routing
+- **New: `-v` flag** — show version without entering the full command
+
 ### [v0.14.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.14.0)
 
 - **New: Device auth login** — `longbridge login` now uses OAuth device flow; displays a URL and code to authorize on any device, works in SSH and headless environments; `--headless` flag removed

--- a/docs/zh-CN/docs/changelog.md
+++ b/docs/zh-CN/docs/changelog.md
@@ -5,7 +5,18 @@ slug: changelog
 sidebar_position: 7
 ---
 
+## 2026-04-08
+
+### CLI v0.14.2
+
+- **`--lang` 标志** — 为所有命令指定内容语言（`zh-CN`、`zh-HK`、`en`），自动回退到系统 `LANG` 环境变量
+
 ## 2026-04-02
+
+### CLI v0.14.1
+
+- **CN 区域登录** — `longbridge login` 支持中国大陆区域路由
+- **`-v` 标志** — 快速查看版本号
 
 ### CLI v0.14.0
 

--- a/docs/zh-CN/docs/cli.md
+++ b/docs/zh-CN/docs/cli.md
@@ -356,6 +356,15 @@ Longbridge OpenAPI 最高支持每秒 10 次调用，SDK 自动刷新 OAuth Toke
 
 ## Release Notes
 
+### [v0.14.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.14.2)
+
+- **新增：`--lang` 全局标志** — 为所有命令指定内容语言（`zh-CN`、`zh-HK`、`en`），优先级：`--lang` → 系统 `LANG` 环境变量 → `en`
+
+### [v0.14.1](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.14.1)
+
+- **新增：CN 区域登录** — `longbridge login` 支持中国大陆区域路由
+- **新增：`-v` 标志** — 快速查看版本号
+
 ### [v0.14.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.14.0)
 
 - **新增：Device Auth 登录** — `longbridge login` 改为 OAuth Device Flow，显示验证 URL 和 Code，在任意设备完成授权，支持 SSH 和无头环境；`--headless` 标志已移除

--- a/docs/zh-HK/docs/changelog.md
+++ b/docs/zh-HK/docs/changelog.md
@@ -5,7 +5,18 @@ slug: changelog
 sidebar_position: 7
 ---
 
+## 2026-04-08
+
+### CLI v0.14.2
+
+- **`--lang` 標誌** — 為所有指令指定內容語言（`zh-CN`、`zh-HK`、`en`），自動回退到系統 `LANG` 環境變數
+
 ## 2026-04-02
+
+### CLI v0.14.1
+
+- **CN 區域登入** — `longbridge login` 支援中國大陸區域路由
+- **`-v` 標誌** — 快速查看版本號
 
 ### CLI v0.14.0
 

--- a/docs/zh-HK/docs/cli.md
+++ b/docs/zh-HK/docs/cli.md
@@ -356,6 +356,15 @@ Longbridge OpenAPI 最高支援每秒 10 次調用，SDK 自動刷新 OAuth Toke
 
 ## Release Notes
 
+### [v0.14.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.14.2)
+
+- **新增：`--lang` 全域標誌** — 為所有指令指定內容語言（`zh-CN`、`zh-HK`、`en`），優先級：`--lang` → 系統 `LANG` 環境變數 → `en`
+
+### [v0.14.1](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.14.1)
+
+- **新增：CN 區域登入** — `longbridge login` 支援中國大陸區域路由
+- **新增：`-v` 標誌** — 快速查看版本號
+
 ### [v0.14.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.14.0)
 
 - **新增：Device Auth 登入** — `longbridge login` 改為 OAuth Device Flow，顯示驗證 URL 和 Code，在任意裝置完成授權，支援 SSH 和無頭環境；`--headless` 標誌已移除


### PR DESCRIPTION
## Summary
- Add v0.14.2 release notes: `--lang` global flag for content language
- Add v0.14.1 release notes: CN region login support, `-v` flag
- Updated in cli.md and changelog.md across all three language versions (en, zh-CN, zh-HK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)