### PR TITLE
feat(nav): add frosted glass blur effect on scroll

### DIFF
--- a/docs/.vitepress/theme/style/custom.scss
+++ b/docs/.vitepress/theme/style/custom.scss
@@ -6,3 +6,27 @@
     background-color: transparent;
   }
 }
+
+// 滚动后导航栏玻璃模糊效果（VitePress 在顶部时添加 .top 类，滚动后移除）
+.VPNavBar:not(.top) {
+  backdrop-filter: blur(15px) !important;
+  -webkit-backdrop-filter: blur(15px) !important;
+  background-color: rgba(255, 255, 255, 0.7) !important;
+  border-bottom-color: transparent !important;
+  transition: background-color 0.25s, backdrop-filter 0.25s !important;
+}
+
+.dark .VPNavBar:not(.top) {
+  background-color: rgba(15, 15, 15, 0.7) !important;
+}
+
+// 滚动后让内部子元素背景透明，确保 backdrop-filter 效果穿透显示
+.VPNavBar:not(.top) .content-body,
+.VPNavBar:not(.top) .title {
+  background-color: transparent !important;
+}
+
+.VPNavBar:not(.top) .divider-line,
+.VPNavBar:not(.top) .divider {
+  background-color: transparent !important;
+}


### PR DESCRIPTION
## Summary

- 滚动后导航栏显示玻璃模糊效果（`backdrop-filter: blur(15px)` + 半透明背景）
- 利用 VitePress 内置的 `.top` 类（`y === 0` 时添加，滚动后移除）触发样式切换
- 支持 dark mode（深色半透明背景）
- 隐藏滚动后的底部分隔线

🤖 Generated with [Claude Code](https://claude.com/claude-code)