### PR TITLE
fix: update issue links from longbridge/openapi to longbridge/developers

### DIFF
--- a/docs/.vitepress/locales/en/nav.ts
+++ b/docs/.vitepress/locales/en/nav.ts
@@ -11,6 +11,6 @@ export const nav = (): DefaultTheme.NavItem[] => {
       : { text: 'Docs', link: '/docs', activeMatch: '^(/en)?/docs(?!/api)' },
     { text: 'API Reference', link: '/docs/api', activeMatch: '^(/en)?/docs/api' },
     { text: 'SDK', link: '/sdk', activeMatch: '^(/en)?/sdk' },
-    { text: 'Issues', link: 'https://github.com/longbridge/openapi/issues', target: '_blank' },
+    { text: 'Issues', link: 'https://github.com/longbridge/developers/issues', target: '_blank' },
   ])
 }

--- a/docs/.vitepress/locales/zh-CN/nav.ts
+++ b/docs/.vitepress/locales/zh-CN/nav.ts
@@ -11,6 +11,6 @@ export const nav = (lang: string): DefaultTheme.NavItem[] => {
       : { text: '文档', link: `/${lang}/docs`, activeMatch: `^/${lang}/docs(?!/api)` },
     { text: 'API 参考', link: `/${lang}/docs/api`, activeMatch: `^/${lang}/docs/api` },
     { text: 'SDK', link: `/${lang}/sdk`, activeMatch: `^/${lang}/sdk` },
-    { text: 'Issues', link: 'https://github.com/longbridge/openapi/issues', target: '_blank' },
+    { text: 'Issues', link: 'https://github.com/longbridge/developers/issues', target: '_blank' },
   ])
 }

--- a/docs/.vitepress/locales/zh-HK/nav.ts
+++ b/docs/.vitepress/locales/zh-HK/nav.ts
@@ -11,6 +11,6 @@ export const nav = (lang: string): DefaultTheme.NavItem[] => {
       : { text: '文檔', link: `/${lang}/docs`, activeMatch: `^/${lang}/docs(?!/api)` },
     { text: 'API 參考', link: `/${lang}/docs/api`, activeMatch: `^/${lang}/docs/api` },
     { text: 'SDK', link: `/${lang}/sdk`, activeMatch: `^/${lang}/sdk` },
-    { text: 'Issues', link: 'https://github.com/longbridge/openapi/issues', target: '_blank' },
+    { text: 'Issues', link: 'https://github.com/longbridge/developers/issues', target: '_blank' },
   ])
 }

--- a/docs/en/docs/getting-started.md
+++ b/docs/en/docs/getting-started.md
@@ -1811,4 +1811,4 @@ If there are any questions or suggestions, please feel free to post an issue on 
 
 Or there have a lot old discussion in the GitHub issue, you can search the issue to find the answer.
 
-- GitHub: https://github.com/longbridge/openapi/issues
+- GitHub: https://github.com/longbridge/developers/issues

--- a/docs/zh-CN/docs/getting-started.md
+++ b/docs/zh-CN/docs/getting-started.md
@@ -1812,4 +1812,4 @@ SDK 的详细 API 文档请访问：https://longbridge.github.io/openapi/
 
 在 GitHub 上，也有很多历史的讨论和问题可以参考，你也可以试着搜索一下，或许也能找到问题的解决方案。
 
-访问地址：https://github.com/longbridge/openapi/issues
+访问地址：https://github.com/longbridge/developers/issues

--- a/docs/zh-HK/docs/getting-started.md
+++ b/docs/zh-HK/docs/getting-started.md
@@ -1729,4 +1729,4 @@ https://longbridge.github.io/openapi/
 
 在 GitHub 上，也有很多歷史的討論和問題可以參考，你也可以試著搜尋一下，或許也能找到問題的解決方案。
 
-訪問網址：https://github.com/longbridge/openapi/issues
+訪問網址：https://github.com/longbridge/developers/issues


### PR DESCRIPTION
Issues 已从 longbridge/openapi 迁移至 longbridge/developers，同步更新文档中所有相关链接。

## 修改内容

- `docs/.vitepress/locales/{en,zh-CN,zh-HK}/nav.ts` — 导航栏 Issues 链接
- `docs/{en,zh-CN,zh-HK}/docs/getting-started.md` — 文档正文中的 Issues 链接