### PR TITLE
style: navbar glass, sidebar bg, doc gradient, search pill, nav feedback

### DIFF
--- a/docs/.vitepress/locales/en/nav.ts
+++ b/docs/.vitepress/locales/en/nav.ts
@@ -9,6 +9,6 @@ export const nav = (): DefaultTheme.NavItem[] => {
     { text: 'CLI', link: '/docs/cli', activeMatch: '^(/en)?/docs/cli' },
     { text: 'API Reference', link: '/docs/api', activeMatch: '^(/en)?/docs/api' },
     { text: 'SDK', link: '/sdk', activeMatch: '^(/en)?/sdk' },
-    { text: 'Issues', link: 'https://github.com/longbridge/developers/issues', target: '_blank' },
+    { text: 'Feedback', link: 'https://github.com/longbridge/developers/issues', target: '_blank' },
   ])
 }

--- a/docs/.vitepress/locales/zh-CN/nav.ts
+++ b/docs/.vitepress/locales/zh-CN/nav.ts
@@ -9,6 +9,6 @@ export const nav = (lang: string): DefaultTheme.NavItem[] => {
     { text: 'CLI', link: `/${lang}/docs/cli`, activeMatch: `^/${lang}/docs/cli` },
     { text: 'API 参考', link: `/${lang}/docs/api`, activeMatch: `^/${lang}/docs/api` },
     { text: 'SDK', link: `/${lang}/sdk`, activeMatch: `^/${lang}/sdk` },
-    { text: 'Issues', link: 'https://github.com/longbridge/developers/issues', target: '_blank' },
+    { text: 'Feedback', link: 'https://github.com/longbridge/developers/issues', target: '_blank' },
   ])
 }

--- a/docs/.vitepress/locales/zh-HK/nav.ts
+++ b/docs/.vitepress/locales/zh-HK/nav.ts
@@ -9,6 +9,6 @@ export const nav = (lang: string): DefaultTheme.NavItem[] => {
     { text: 'CLI', link: `/${lang}/docs/cli`, activeMatch: `^/${lang}/docs/cli` },
     { text: 'API 參考', link: `/${lang}/docs/api`, activeMatch: `^/${lang}/docs/api` },
     { text: 'SDK', link: `/${lang}/sdk`, activeMatch: `^/${lang}/sdk` },
-    { text: 'Issues', link: 'https://github.com/longbridge/developers/issues', target: '_blank' },
+    { text: 'Feedback', link: 'https://github.com/longbridge/developers/issues', target: '_blank' },
   ])
 }

--- a/docs/.vitepress/md-plugins/gen-try-it.ts/index.ts
+++ b/docs/.vitepress/md-plugins/gen-try-it.ts/index.ts
@@ -222,8 +222,6 @@ export const GenTryItPlugin = (md: MarkdownIt) => {
 
       state.env.frontmatter.httpInfo = httpResult
       state.env.frontmatter.parametersTable = parametersResult || {}
-
-      addTryItComponent(state)
     }
 
     // 将解析结果写入 frontmatter 中供其他组件访问

--- a/docs/.vitepress/theme/style/custom.scss
+++ b/docs/.vitepress/theme/style/custom.scss
@@ -7,17 +7,30 @@
   }
 }
 
+:root:root {
+  --vp-c-divider: rgba(0, 0, 0, 0.06);
+  --vp-c-gutter: var(--vp-c-divider);
+  --vp-navbar-bg: rgba(255, 255, 255, 0.7);
+  --vp-navbar-border: rgba(0, 0, 0, 0.08);
+  --vp-sidebar-bg-color: var(--vp-c-bg);
+}
+
+html.dark {
+  --vp-c-divider: rgba(255, 255, 255, 0.06);
+  --vp-navbar-bg: rgba(15, 15, 15, 0.7);
+  --vp-navbar-border: rgba(255, 255, 255, 0.08);
+  --vp-sidebar-bg-color: var(--vp-c-bg);
+}
+
 // 滚动后导航栏玻璃模糊效果（VitePress 在顶部时添加 .top 类，滚动后移除）
 .VPNavBar:not(.top) {
   backdrop-filter: blur(15px) !important;
   -webkit-backdrop-filter: blur(15px) !important;
-  background-color: rgba(255, 255, 255, 0.7) !important;
-  border-bottom-color: transparent !important;
-  transition: background-color 0.25s, backdrop-filter 0.25s !important;
-}
-
-.dark .VPNavBar:not(.top) {
-  background-color: rgba(15, 15, 15, 0.7) !important;
+  background-color: var(--vp-navbar-bg) !important;
+  border-bottom: 1px solid var(--vp-navbar-border) !important;
+  transition:
+    background-color 0.25s,
+    backdrop-filter 0.25s !important;
 }
 
 // 滚动后让内部子元素背景透明，确保 backdrop-filter 效果穿透显示
@@ -29,4 +42,44 @@
 .VPNavBar:not(.top) .divider-line,
 .VPNavBar:not(.top) .divider {
   background-color: transparent !important;
+}
+
+// 去掉右侧 padding 避免渐变被截断
+.VPContent.has-sidebar {
+  padding-right: 0 !important;
+}
+
+// VPDoc 内容区域品牌色镜像渐变背景
+.VPDoc {
+  position: relative;
+}
+
+.VPDoc::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(
+    680px 320px at 50% 0%,
+    color-mix(in srgb, var(--vp-c-brand-1) 8%, transparent) 25%,
+    transparent 100%
+  );
+  z-index: 0;
+}
+
+// 搜索框圆角样式
+.VPNavBarSearchButton {
+  padding-left: 20px !important;
+  padding-right: 20px !important;
+  border-radius: 20px !important;
+
+  .keys {
+    border: 0 !important;
+    font-size: 12px !important;
+    color: var(--vp-c-text-3) !important;
+  }
+}
+
+.DocSearch-Button {
+  border-radius: 20px !important;
 }


### PR DESCRIPTION
## Summary

- Navbar glass blur + border-bottom on scroll (CSS variables for light/dark)
- Soften `--vp-c-divider`; sidebar background matches page background
- Radial brand-color gradient on `.VPDoc` content area
- Remove `padding-right` from `.VPContent.has-sidebar` so gradient fills full width
- Search button rounded to pill style
- Nav item "Issues" → "Feedback" across all 3 locales
- Remove `<TryIt/>` button auto-injection from `gen-try-it` plugin

## Test plan

- [ ] Scroll docs page — navbar should show blur + subtle border-bottom
- [ ] Check light and dark mode — navbar bg/border variables apply correctly
- [ ] Sidebar background blends with page (no distinct bg color)
- [ ] Doc pages show subtle teal radial gradient at top
- [ ] Gradient fills full width (no right-side truncation)
- [ ] Search button appears pill-shaped
- [ ] Nav shows "Feedback" (not "Issues") in all locales
- [ ] API reference pages no longer show Try It button

🤖 Generated with [Claude Code](https://claude.com/claude-code)