### PR TITLE
docs(cli): add missing subcommands and statement docs

### DIFF
--- a/docs/en/docs/cli/account/statement.md
+++ b/docs/en/docs/cli/account/statement.md
@@ -1,0 +1,87 @@
+---
+title: 'statement'
+sidebar_label: 'statement'
+sidebar_position: 7
+---
+
+# longbridge statement
+
+Download and export account statements — daily settlement summaries or monthly reports.
+
+## Basic Usage
+
+```bash
+longbridge statement
+```
+
+```
+| date       | file_key                             |
+|------------|--------------------------------------|
+| 2026-04-10 | stmt_daily_20260410_abc123           |
+| 2026-04-09 | stmt_daily_20260409_def456           |
+| 2026-04-08 | stmt_daily_20260408_ghi789           |
+...
+```
+
+## Examples
+
+### List recent daily statements
+
+```bash
+longbridge statement
+# Specify a start date and limit
+longbridge statement --start-date 20260401 --limit 10
+```
+
+Lists available daily statements with their dates and file keys. File keys are used with the `export` subcommand.
+
+### List monthly statements
+
+```bash
+longbridge statement --type monthly
+# Limit to last 6 months
+longbridge statement --type monthly --limit 6
+```
+
+Returns monthly summary statements instead of daily ones.
+
+### List statements (subcommand form)
+
+```bash
+longbridge statement list
+longbridge statement list --type daily --start-date 20260401
+```
+
+Equivalent to `longbridge statement` — the `list` subcommand makes the intent explicit.
+
+### Export a statement to terminal
+
+```bash
+longbridge statement export --file-key stmt_daily_20260410_abc123
+```
+
+Prints all non-empty sections of the statement as Markdown to stdout. Use a `file_key` from `longbridge statement list`.
+
+### Export specific sections
+
+```bash
+# Export only equity holdings and stock trades
+longbridge statement export --file-key stmt_daily_20260410_abc123 --section equity_holdings --section stock_trades
+```
+
+Available sections include: `asset`, `account_balances`, `equity_holdings`, `account_balance_changes`, `stock_trades`, `equity_holding_changes`, `option_trades`, `fund_trades`, and more.
+
+### Export as CSV files
+
+```bash
+# Export all sections to a directory as CSV
+longbridge statement export --file-key stmt_daily_20260410_abc123 -o ./statements/
+# Export specific sections as CSV
+longbridge statement export --file-key stmt_daily_20260410_abc123 --section equity_holdings --export-format csv -o ./statements/
+```
+
+When `-o` is provided, the default export format switches to CSV. Each section is saved as a separate file in the output directory.
+
+## Requirements
+
+A valid OAuth login is required. Run `longbridge login` if you have not yet authenticated.

--- a/docs/en/docs/cli/content/topic.md
+++ b/docs/en/docs/cli/content/topic.md
@@ -65,3 +65,58 @@ longbridge topic TSLA.US --format json | jq '[.[] | select(.likes_count > 10)]'
 ```
 
 Combines with `jq` to surface the most-discussed posts. Useful for gauging retail sentiment spikes around earnings or news events.
+
+### View your own topics
+
+```bash
+longbridge topic mine
+# Filter by content type
+longbridge topic mine --type article
+longbridge topic mine --type post
+```
+
+Lists topics you have published. Use `--page` and `--size` to paginate through results.
+
+### View replies to a topic
+
+```bash
+longbridge topic replies 39798312
+# Paginate through replies
+longbridge topic replies 39798312 --page 2 --size 10
+```
+
+Lists replies under a specific topic. Use the `id` from the topic list.
+
+### Publish a new post
+
+```bash
+# Short-form post (plain text)
+longbridge topic create --body "TSLA earnings beat expectations, bullish on Q3 guidance"
+# Post with associated tickers
+longbridge topic create --body "Watching NVDA and ARM for AI infrastructure plays" --tickers NVDA.US,ARM.US
+```
+
+Creates a short-form community post. Text is plain text. Use `--tickers` to tag related symbols (max 10, comma-separated).
+
+### Publish an article
+
+```bash
+longbridge topic create --type article --title "Tesla Q1 2026 Earnings Analysis" --body "## Key Takeaways\n\nRevenue grew 15% YoY..."
+```
+
+Creates a long-form article with a title. The body supports Markdown formatting. `--title` is required for articles.
+
+### Reply to a topic
+
+```bash
+# Top-level reply
+longbridge topic create-reply 39798312 --body "Great analysis, thanks for sharing"
+# Nested reply (reply to a specific reply)
+longbridge topic create-reply 39798312 --body "Agreed" --reply-to 50012345
+```
+
+Posts a reply to a community topic. Use `--reply-to` with a reply ID (from `topic replies`) to create a nested reply.
+
+## Requirements
+
+A valid OAuth login is required for `mine`, `create`, and `create-reply`. Run `longbridge login` if you have not yet authenticated.

--- a/docs/en/docs/cli/market-data/kline.md
+++ b/docs/en/docs/cli/market-data/kline.md
@@ -40,11 +40,11 @@ longbridge kline TSLA.US --period 1h --count 48
 
 Use `--period` to switch granularity (e.g. `1m`, `5m`, `15m`, `30m`, `1h`, `day`, `week`, `month`, `year`) and `--count` to control how many bars are returned.
 
-### Historical range
+### Historical date range
 
 ```bash
-longbridge kline TSLA.US --period day --start 2025-01-01 --end 2025-03-31
-longbridge kline TSLA.US --period day --start 2025-01-01 --end 2025-03-31 --format json
+longbridge kline history TSLA.US --period day --start 2025-01-01 --end 2025-03-31
+longbridge kline history TSLA.US --period day --start 2025-01-01 --end 2025-03-31 --format json
 ```
 
-Fetch candles for a specific date window using `--start` and `--end` (format: `YYYY-MM-DD`). The `time` field in JSON output represents the candle open time — for US daily candles, this is US Eastern midnight expressed in UTC.
+Use the `history` subcommand with `--start` and `--end` (format: `YYYY-MM-DD`) to fetch candles for a specific date window. `--adjust forward` applies forward-adjusted prices. The `time` field in JSON output represents the candle open time — for US daily candles, this is US Eastern midnight expressed in UTC.

--- a/docs/en/docs/cli/research/investors.md
+++ b/docs/en/docs/cli/research/investors.md
@@ -54,3 +54,26 @@ Portfolio: 42 positions, total value ~$274.16B
 ```
 
 Pass a CIK to see the full list of equity positions reported by that fund manager. CIK `0001067983` is Berkshire Hathaway.
+
+### Compare position changes between filings
+
+```bash
+# Changes between the two most recent filings
+longbridge investors changes 0001067983
+# Compare against a specific base period
+longbridge investors changes 0001067983 --from 2024-09-30
+```
+
+```
+BERKSHIRE HATHAWAY INC — changes vs 2024-09-30
+
+| action  | company                | shares_change | value_change | current_shares | current_value |
+|---------|------------------------|---------------|--------------|----------------|---------------|
+| NEW     | CONSTELLATION BRANDS   | +5.21M        | +$1.24B      | 5.21M          | $1.24B        |
+| ADDED   | SIRIUS XM HOLDINGS INC | +57.83M       | +$1.52B      | 144.42M        | $3.80B        |
+| REDUCED | CHEVRON CORP NEW       | -12.50M       | -$1.93B      | 130.16M        | $19.84B       |
+| EXITED  | FLOOR & DECOR HLDGS    | -3.97M        | -$414.30M    | 0              | $0            |
+...
+```
+
+Shows NEW positions, ADDED (increased), REDUCED (decreased), and EXITED positions between two filing periods. Defaults to comparing the latest filing against the previous one.

--- a/docs/zh-CN/docs/cli/account/statement.md
+++ b/docs/zh-CN/docs/cli/account/statement.md
@@ -1,0 +1,87 @@
+---
+title: 'statement'
+sidebar_label: 'statement'
+sidebar_position: 7
+---
+
+# longbridge statement
+
+下载和导出账户结算单——每日结算摘要或月度报告。
+
+## 基本用法
+
+```bash
+longbridge statement
+```
+
+```
+| date       | file_key                             |
+|------------|--------------------------------------|
+| 2026-04-10 | stmt_daily_20260410_abc123           |
+| 2026-04-09 | stmt_daily_20260409_def456           |
+| 2026-04-08 | stmt_daily_20260408_ghi789           |
+...
+```
+
+## 示例
+
+### 查看近期日结算单
+
+```bash
+longbridge statement
+# 指定起始日期和数量
+longbridge statement --start-date 20260401 --limit 10
+```
+
+列出可用的日结算单及其日期和文件 key。文件 key 用于 `export` 子命令。
+
+### 查看月结算单
+
+```bash
+longbridge statement --type monthly
+# 仅查看近 6 个月
+longbridge statement --type monthly --limit 6
+```
+
+返回月度汇总结算单。
+
+### 列出结算单（子命令形式）
+
+```bash
+longbridge statement list
+longbridge statement list --type daily --start-date 20260401
+```
+
+与 `longbridge statement` 等效——`list` 子命令使意图更明确。
+
+### 导出结算单到终端
+
+```bash
+longbridge statement export --file-key stmt_daily_20260410_abc123
+```
+
+将结算单所有非空板块以 Markdown 格式输出到终端。`file_key` 来自 `longbridge statement list`。
+
+### 导出指定板块
+
+```bash
+# 仅导出持仓和股票交易
+longbridge statement export --file-key stmt_daily_20260410_abc123 --section equity_holdings --section stock_trades
+```
+
+可用板块包括：`asset`、`account_balances`、`equity_holdings`、`account_balance_changes`、`stock_trades`、`equity_holding_changes`、`option_trades`、`fund_trades` 等。
+
+### 导出为 CSV 文件
+
+```bash
+# 导出全部板块到目录（CSV 格式）
+longbridge statement export --file-key stmt_daily_20260410_abc123 -o ./statements/
+# 导出指定板块为 CSV
+longbridge statement export --file-key stmt_daily_20260410_abc123 --section equity_holdings --export-format csv -o ./statements/
+```
+
+提供 `-o` 时默认导出格式为 CSV。每个板块保存为输出目录下的独立文件。
+
+## 前置条件
+
+需要有效的 OAuth 登录。如未认证请先执行 `longbridge login`。

--- a/docs/zh-CN/docs/cli/content/topic.md
+++ b/docs/zh-CN/docs/cli/content/topic.md
@@ -65,3 +65,58 @@ longbridge topic TSLA.US --format json | jq '[.[] | select(.likes_count > 10)]'
 ```
 
 结合 `jq` 筛选讨论最热的帖子。适用于在财报或重大新闻事件前后追踪散户情绪变化。
+
+### 查看自己发布的帖子
+
+```bash
+longbridge topic mine
+# 按内容类型筛选
+longbridge topic mine --type article
+longbridge topic mine --type post
+```
+
+列出你已发布的帖子。使用 `--page` 和 `--size` 进行分页。
+
+### 查看帖子回复
+
+```bash
+longbridge topic replies 39798312
+# 分页查看回复
+longbridge topic replies 39798312 --page 2 --size 10
+```
+
+列出指定帖子下的回复。使用帖子列表中的 `id`。
+
+### 发布短帖
+
+```bash
+# 短帖（纯文本）
+longbridge topic create --body "TSLA 财报超预期，看好 Q3 指引"
+# 关联标的
+longbridge topic create --body "关注 NVDA 和 ARM 的 AI 基础设施布局" --tickers NVDA.US,ARM.US
+```
+
+创建一条短帖。正文为纯文本。使用 `--tickers` 关联相关标的（最多 10 个，逗号分隔）。
+
+### 发布文章
+
+```bash
+longbridge topic create --type article --title "Tesla Q1 2026 财报分析" --body "## 核心要点\n\n营收同比增长 15%..."
+```
+
+创建一篇长文。正文支持 Markdown 格式。文章类型必须提供 `--title`。
+
+### 回复帖子
+
+```bash
+# 一级回复
+longbridge topic create-reply 39798312 --body "分析得很好，感谢分享"
+# 嵌套回复（回复某条回复）
+longbridge topic create-reply 39798312 --body "同意" --reply-to 50012345
+```
+
+发表帖子回复。使用 `--reply-to` 指定回复 ID（来自 `topic replies`）可创建嵌套回复。
+
+## 前置条件
+
+`mine`、`create` 和 `create-reply` 需要有效的 OAuth 登录。如未认证请先执行 `longbridge login`。

--- a/docs/zh-CN/docs/cli/market-data/kline.md
+++ b/docs/zh-CN/docs/cli/market-data/kline.md
@@ -40,11 +40,11 @@ longbridge kline TSLA.US --period 1h --count 48
 
 使用 `--period` 切换粒度（如 `1m`、`5m`、`15m`、`30m`、`1h`、`day`、`week`、`month`、`year`），用 `--count` 控制返回的 K 线条数。
 
-### 历史区间
+### 历史日期范围
 
 ```bash
-longbridge kline TSLA.US --period day --start 2025-01-01 --end 2025-03-31
-longbridge kline TSLA.US --period day --start 2025-01-01 --end 2025-03-31 --format json
+longbridge kline history TSLA.US --period day --start 2025-01-01 --end 2025-03-31
+longbridge kline history TSLA.US --period day --start 2025-01-01 --end 2025-03-31 --format json
 ```
 
-用 `--start` 和 `--end` 指定日期窗口（格式：`YYYY-MM-DD`）获取历史 K 线。JSON 输出中的 `time` 字段表示 K 线开盘时间——美股日线以 UTC 时间表示美东时间零点。
+使用 `history` 子命令配合 `--start` 和 `--end`（格式：`YYYY-MM-DD`）获取指定日期窗口的 K 线。`--adjust forward` 可获取前复权价格。JSON 输出中的 `time` 字段表示 K 线开盘时间——美股日线以 UTC 时间表示美东时间零点。

--- a/docs/zh-CN/docs/cli/research/investors.md
+++ b/docs/zh-CN/docs/cli/research/investors.md
@@ -54,3 +54,26 @@ Portfolio: 42 positions, total value ~$274.16B
 ```
 
 传入 CIK 可查看该基金经理申报的完整股票持仓列表。CIK `0001067983` 为伯克希尔·哈撒韦。
+
+### 对比两期持仓变动
+
+```bash
+# 对比最近两期申报的变动
+longbridge investors changes 0001067983
+# 指定基准期对比
+longbridge investors changes 0001067983 --from 2024-09-30
+```
+
+```
+BERKSHIRE HATHAWAY INC — changes vs 2024-09-30
+
+| action  | company                | shares_change | value_change | current_shares | current_value |
+|---------|------------------------|---------------|--------------|----------------|---------------|
+| NEW     | CONSTELLATION BRANDS   | +5.21M        | +$1.24B      | 5.21M          | $1.24B        |
+| ADDED   | SIRIUS XM HOLDINGS INC | +57.83M       | +$1.52B      | 144.42M        | $3.80B        |
+| REDUCED | CHEVRON CORP NEW       | -12.50M       | -$1.93B      | 130.16M        | $19.84B       |
+| EXITED  | FLOOR & DECOR HLDGS    | -3.97M        | -$414.30M    | 0              | $0            |
+...
+```
+
+展示两期申报之间的新增（NEW）、加仓（ADDED）、减仓（REDUCED）和清仓（EXITED）持仓变动。默认对比最新一期与前一期的变化。

--- a/docs/zh-HK/docs/cli/account/statement.md
+++ b/docs/zh-HK/docs/cli/account/statement.md
@@ -1,0 +1,87 @@
+---
+title: 'statement'
+sidebar_label: 'statement'
+sidebar_position: 7
+---
+
+# longbridge statement
+
+下載和匯出賬戶結算單——每日結算摘要或月度報告。
+
+## 基本用法
+
+```bash
+longbridge statement
+```
+
+```
+| date       | file_key                             |
+|------------|--------------------------------------|
+| 2026-04-10 | stmt_daily_20260410_abc123           |
+| 2026-04-09 | stmt_daily_20260409_def456           |
+| 2026-04-08 | stmt_daily_20260408_ghi789           |
+...
+```
+
+## 示例
+
+### 查看近期日結算單
+
+```bash
+longbridge statement
+# 指定起始日期和數量
+longbridge statement --start-date 20260401 --limit 10
+```
+
+列出可用的日結算單及其日期和檔案 key。檔案 key 用於 `export` 子命令。
+
+### 查看月結算單
+
+```bash
+longbridge statement --type monthly
+# 僅查看近 6 個月
+longbridge statement --type monthly --limit 6
+```
+
+返回月度匯總結算單。
+
+### 列出結算單（子命令形式）
+
+```bash
+longbridge statement list
+longbridge statement list --type daily --start-date 20260401
+```
+
+與 `longbridge statement` 等效——`list` 子命令使意圖更明確。
+
+### 匯出結算單到終端
+
+```bash
+longbridge statement export --file-key stmt_daily_20260410_abc123
+```
+
+將結算單所有非空板塊以 Markdown 格式輸出到終端。`file_key` 來自 `longbridge statement list`。
+
+### 匯出指定板塊
+
+```bash
+# 僅匯出持倉和股票交易
+longbridge statement export --file-key stmt_daily_20260410_abc123 --section equity_holdings --section stock_trades
+```
+
+可用板塊包括：`asset`、`account_balances`、`equity_holdings`、`account_balance_changes`、`stock_trades`、`equity_holding_changes`、`option_trades`、`fund_trades` 等。
+
+### 匯出為 CSV 檔案
+
+```bash
+# 匯出全部板塊到目錄（CSV 格式）
+longbridge statement export --file-key stmt_daily_20260410_abc123 -o ./statements/
+# 匯出指定板塊為 CSV
+longbridge statement export --file-key stmt_daily_20260410_abc123 --section equity_holdings --export-format csv -o ./statements/
+```
+
+提供 `-o` 時預設匯出格式為 CSV。每個板塊儲存為輸出目錄下的獨立檔案。
+
+## 前置條件
+
+需要有效的 OAuth 登入。如未認證請先執行 `longbridge login`。

--- a/docs/zh-HK/docs/cli/content/topic.md
+++ b/docs/zh-HK/docs/cli/content/topic.md
@@ -65,3 +65,58 @@ longbridge topic TSLA.US --format json | jq '[.[] | select(.likes_count > 10)]'
 ```
 
 結合 `jq` 篩選討論最熱的帖子。適用於在財報或重大新聞事件前後追蹤散戶情緒變化。
+
+### 查看自己發佈的帖子
+
+```bash
+longbridge topic mine
+# 按內容類型篩選
+longbridge topic mine --type article
+longbridge topic mine --type post
+```
+
+列出你已發佈的帖子。使用 `--page` 和 `--size` 進行分頁。
+
+### 查看帖子回覆
+
+```bash
+longbridge topic replies 39798312
+# 分頁查看回覆
+longbridge topic replies 39798312 --page 2 --size 10
+```
+
+列出指定帖子下的回覆。使用帖子列表中的 `id`。
+
+### 發佈短帖
+
+```bash
+# 短帖（純文本）
+longbridge topic create --body "TSLA 財報超預期，看好 Q3 指引"
+# 關聯標的
+longbridge topic create --body "關注 NVDA 和 ARM 的 AI 基礎設施佈局" --tickers NVDA.US,ARM.US
+```
+
+建立一條短帖。正文為純文本。使用 `--tickers` 關聯相關標的（最多 10 個，逗號分隔）。
+
+### 發佈文章
+
+```bash
+longbridge topic create --type article --title "Tesla Q1 2026 財報分析" --body "## 核心要點\n\n營收同比增長 15%..."
+```
+
+建立一篇長文。正文支援 Markdown 格式。文章類型必須提供 `--title`。
+
+### 回覆帖子
+
+```bash
+# 一級回覆
+longbridge topic create-reply 39798312 --body "分析得很好，感謝分享"
+# 嵌套回覆（回覆某條回覆）
+longbridge topic create-reply 39798312 --body "同意" --reply-to 50012345
+```
+
+發表帖子回覆。使用 `--reply-to` 指定回覆 ID（來自 `topic replies`）可建立嵌套回覆。
+
+## 前置條件
+
+`mine`、`create` 和 `create-reply` 需要有效的 OAuth 登入。如未認證請先執行 `longbridge login`。

--- a/docs/zh-HK/docs/cli/market-data/kline.md
+++ b/docs/zh-HK/docs/cli/market-data/kline.md
@@ -40,11 +40,11 @@ longbridge kline TSLA.US --period 1h --count 48
 
 使用 `--period` 切換粒度（如 `1m`、`5m`、`15m`、`30m`、`1h`、`day`、`week`、`month`、`year`），用 `--count` 控制返回的 K 線條數。
 
-### 歷史區間
+### 歷史日期範圍
 
 ```bash
-longbridge kline TSLA.US --period day --start 2025-01-01 --end 2025-03-31
-longbridge kline TSLA.US --period day --start 2025-01-01 --end 2025-03-31 --format json
+longbridge kline history TSLA.US --period day --start 2025-01-01 --end 2025-03-31
+longbridge kline history TSLA.US --period day --start 2025-01-01 --end 2025-03-31 --format json
 ```
 
-用 `--start` 和 `--end` 指定日期窗口（格式：`YYYY-MM-DD`）取得歷史 K 線。JSON 輸出中的 `time` 欄位表示 K 線開盤時間——美股日線以 UTC 時間表示美東時間零點。
+使用 `history` 子命令配合 `--start` 和 `--end`（格式：`YYYY-MM-DD`）取得指定日期窗口的 K 線。`--adjust forward` 可取得前復權價格。JSON 輸出中的 `time` 欄位表示 K 線開盤時間——美股日線以 UTC 時間表示美東時間零點。

--- a/docs/zh-HK/docs/cli/research/investors.md
+++ b/docs/zh-HK/docs/cli/research/investors.md
@@ -54,3 +54,26 @@ Portfolio: 42 positions, total value ~$274.16B
 ```
 
 傳入 CIK 可查看該基金經理申報的完整股票持倉列表。CIK `0001067983` 為伯克希爾·哈撒韋。
+
+### 對比兩期持倉變動
+
+```bash
+# 對比最近兩期申報的變動
+longbridge investors changes 0001067983
+# 指定基準期對比
+longbridge investors changes 0001067983 --from 2024-09-30
+```
+
+```
+BERKSHIRE HATHAWAY INC — changes vs 2024-09-30
+
+| action  | company                | shares_change | value_change | current_shares | current_value |
+|---------|------------------------|---------------|--------------|----------------|---------------|
+| NEW     | CONSTELLATION BRANDS   | +5.21M        | +$1.24B      | 5.21M          | $1.24B        |
+| ADDED   | SIRIUS XM HOLDINGS INC | +57.83M       | +$1.52B      | 144.42M        | $3.80B        |
+| REDUCED | CHEVRON CORP NEW       | -12.50M       | -$1.93B      | 130.16M        | $19.84B       |
+| EXITED  | FLOOR & DECOR HLDGS    | -3.97M        | -$414.30M    | 0              | $0            |
+...
+```
+
+展示兩期申報之間的新增（NEW）、加倉（ADDED）、減倉（REDUCED）和清倉（EXITED）持倉變動。預設對比最新一期與前一期的變化。


### PR DESCRIPTION
## Summary
- **topic**: Added `mine`, `create`, `replies`, `create-reply` subcommand docs (previously only had list and detail)
- **kline**: Fixed `history` subcommand syntax — was incorrectly using non-existent top-level `--start`/`--end` flags
- **investors**: Added `changes` subcommand for comparing position changes between two 13F filings
- **statement**: Created new command docs covering `list` and `export` subcommands (was completely missing)

All changes synced across en, zh-CN, zh-HK.

## Test plan
- [ ] Verify `bun run dev` builds without errors
- [ ] Check topic, kline, investors, statement pages render correctly in all 3 languages
- [ ] Confirm sidebar shows statement under Portfolio & Account section

🤖 Generated with [Claude Code](https://claude.com/claude-code)