### PR TITLE
Fix stats-grid popover item links and icon alignment

### DIFF
--- a/docs/.vitepress/theme/components/NewHomePage/PlatformStats.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/PlatformStats.vue
@@ -199,18 +199,16 @@ const stats = computed(() => [
                   <span class="hc-count">{{ stat.value }}{{ stat.suffix }}</span>
                 </div>
                 <div class="hc-items">
-                  <a
+                  <div
                     v-for="item in stat.card.items"
                     :key="item.name"
-                    :href="item.link"
-                    class="hc-item"
-                    :class="{ 'hc-item-link': !!item.link }">
+                    class="hc-item">
                     <span class="hc-item-icon" v-html="item.icon" />
                     <div class="hc-item-text">
                       <span class="hc-item-name">{{ item.name }}</span>
                       <span class="hc-item-desc">{{ item.desc }}</span>
                     </div>
-                  </a>
+                  </div>
                 </div>
                 <a :href="stat.link" class="hc-footer">
                   Learn more
@@ -375,15 +373,10 @@ const stats = computed(() => [
 
 .hc-item {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 0.4rem;
   padding: 0.35rem 0.375rem;
   border-radius: 0.3rem;
-  text-decoration: none !important;
-  transition: background 0.15s;
-}
-.hc-item-link:hover {
-  background: color-mix(in srgb, var(--vp-c-text-3) 6%, transparent);
 }
 
 .hc-item-icon {

--- a/docs/en/docs/llm.md
+++ b/docs/en/docs/llm.md
@@ -25,8 +25,8 @@ Each of our documents is also available in Markdown format. When accessing them,
 
 For example:
 
-- https://open.longbridge.com/docs/getting-started.md
-- https://open.longbridge.com/docs/quote/pull/static.md
+- <https://open.longbridge.com/docs/getting-started.md>
+- <https://open.longbridge.com/docs/quote/pull/static.md>
 
 ## Longbridge.com Markdown Access (AI-friendly)
 
@@ -39,7 +39,7 @@ You can get markdown content in either way:
 
 Examples:
 
-- `https://longbridge.com/en/pricing.md`
+- [https://longbridge.com/en/topics.md](https://longbridge.com/en/topics.md)
 - `curl -H "Accept: text/markdown" https://longbridge.com/quote/TSLA.US`
 
 This is useful for LLM crawlers, RAG indexing, and tool-based content ingestion while keeping page structure clean.

--- a/docs/zh-CN/docs/llm.md
+++ b/docs/zh-CN/docs/llm.md
@@ -25,8 +25,8 @@ OpenAPI 文档遵循 [LLMs 文本](https://llmstxt.org/) 提供 [llms.txt](https
 
 例如：
 
-- https://open.longbridge.com/docs/getting-started.md
-- https://open.longbridge.com/docs/quote/pull/static.md
+- <https://open.longbridge.com/docs/getting-started.md>
+- <https://open.longbridge.com/docs/quote/pull/static.md>
 
 ## longbridge.com 页面 Markdown 获取（AI 友好）
 
@@ -39,7 +39,7 @@ OpenAPI 文档遵循 [LLMs 文本](https://llmstxt.org/) 提供 [llms.txt](https
 
 示例：
 
-- `https://longbridge.com/en/pricing.md`
+- [https://longbridge.com/en/topics.md](https://longbridge.com/en/topics.md)
 - `curl -H "Accept: text/markdown" https://longbridge.com/quote/TSLA.US`
 
 这个能力适合 LLM 抓取、RAG 建索引、以及工具化读取页面内容，并且能保持页面结构清晰。

--- a/docs/zh-HK/docs/llm.md
+++ b/docs/zh-HK/docs/llm.md
@@ -25,8 +25,8 @@ OpenAPI 文件遵循 [LLMs 文本](https://llmstxt.org/) 提供 [llms.txt](https
 
 例如：
 
-- https://open.longbridge.com/docs/getting-started.md
-- https://open.longbridge.com/docs/quote/pull/static.md
+- <https://open.longbridge.com/docs/getting-started.md>
+- <https://open.longbridge.com/docs/quote/pull/static.md>
 
 ## longbridge.com 頁面 Markdown 取得（AI 友好）
 
@@ -39,7 +39,7 @@ OpenAPI 文件遵循 [LLMs 文本](https://llmstxt.org/) 提供 [llms.txt](https
 
 範例：
 
-- `https://longbridge.com/en/pricing.md`
+- [https://longbridge.com/en/topics.md](https://longbridge.com/en/topics.md)
 - `curl -H "Accept: text/markdown" https://longbridge.com/quote/TSLA.US`
 
 這個能力適合 LLM 抓取、RAG 建索引，以及工具化讀取頁面內容，同時保持頁面結構清晰。


### PR DESCRIPTION
- Remove clickable links from hover card items in stats-grid popover
- Change hc-item align-items from flex-start to center for icon alignment
- Fix URL formatting in llm.md across all three locales