### PR TITLE
docs(cli): fix v0.17.0 → v0.16.3 and add release notes

### DIFF
--- a/docs/en/docs/changelog.md
+++ b/docs/en/docs/changelog.md
@@ -6,12 +6,14 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
-## 2026-04-15
+## 2026-04-16
 
-### CLI v0.17.0
+### CLI v0.16.3
 
 - **`auth` subcommand group** — `longbridge auth login` / `auth logout` / `auth status`; new `auth status` shows token validity, expiry, and account info locally without network
 - **`alert enable` / `alert disable`** — toggle alerts on/off without deleting them
+- **Fix: US index symbols** — `.DJI.US`, `.VIX.US` now parse correctly; US indexes require a leading dot
+- **"Did you mean?" hints** — symbol format suggestions when a query returns no data
 
 ## 2026-04-13
 

--- a/docs/en/docs/cli/release-notes.md
+++ b/docs/en/docs/cli/release-notes.md
@@ -7,10 +7,12 @@ sidebar_icon: newspaper
 
 # Release Notes
 
-### v0.17.0
+### v0.16.3
 
 - **`auth` subcommand group** — `longbridge auth login`, `auth logout`, `auth status`; `auth status` shows token validity, expiry, account info, and quote level locally without network
 - **`alert enable` / `alert disable`** — toggle price alerts on/off without deleting them
+- **Fix: US index symbols** — `.DJI.US`, `.VIX.US` and other US index symbols now parse correctly; US indexes require a leading dot (e.g. `.DJI.US`, not `DJI.US`)
+- **"Did you mean?" hints** — when a query returns no data, the CLI suggests the correct symbol format: missing market suffix → `TSLA.US` / `700.HK`; missing leading dot → `.DJI.US`
 
 ### v0.16.1
 

--- a/docs/zh-CN/docs/changelog.md
+++ b/docs/zh-CN/docs/changelog.md
@@ -6,12 +6,14 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
-## 2026-04-15
+## 2026-04-16
 
-### CLI v0.17.0
+### CLI v0.16.3
 
 - **`auth` 子命令组** — `longbridge auth login` / `auth logout` / `auth status`；`auth status` 本地查看 Token 有效性和账户信息，无需网络
 - **`alert enable` / `alert disable`** — 切换价格提醒启用状态，无需删除重建
+- **修复：美股指数 symbol** — `.DJI.US`、`.VIX.US` 现已正确解析；美股指数需要前置点号
+- **"你是否想查询…" 提示** — 查询无结果时给出 symbol 格式建议
 
 ## 2026-04-13
 

--- a/docs/zh-CN/docs/cli/release-notes.md
+++ b/docs/zh-CN/docs/cli/release-notes.md
@@ -7,10 +7,12 @@ sidebar_icon: newspaper
 
 # Release Notes
 
-### v0.17.0
+### v0.16.3
 
 - **`auth` 子命令组** — `longbridge auth login`、`auth logout`、`auth status`；`auth status` 本地检查 Token 有效性、过期时间、账户信息和行情权限，无需网络
 - **`alert enable` / `alert disable`** — 切换价格提醒的启用状态，无需删除重建
+- **修复：美股指数 symbol** — `.DJI.US`、`.VIX.US` 等美股指数 symbol 现已正确解析；美股指数需要前置点号（如 `.DJI.US`，而非 `DJI.US`）
+- **"你是否想查询…" 提示** — 当查询无返回数据时，CLI 会给出 symbol 格式建议：缺少市场后缀 → `TSLA.US` / `700.HK`；缺少前置点号 → `.DJI.US`
 
 ### v0.16.1
 

--- a/docs/zh-HK/docs/changelog.md
+++ b/docs/zh-HK/docs/changelog.md
@@ -6,12 +6,14 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
-## 2026-04-15
+## 2026-04-16
 
-### CLI v0.17.0
+### CLI v0.16.3
 
 - **`auth` 子命令群組** — `longbridge auth login` / `auth logout` / `auth status`；`auth status` 本機查看 Token 有效性和帳戶資訊，無需網路
 - **`alert enable` / `alert disable`** — 切換到價提醒啟用狀態，無需刪除重建
+- **修正：美股指數 symbol** — `.DJI.US`、`.VIX.US` 現已正確解析；美股指數需要前置點號
+- **「您是否想查詢…」提示** — 查詢無結果時給出 symbol 格式建議
 
 ## 2026-04-13
 

--- a/docs/zh-HK/docs/cli/release-notes.md
+++ b/docs/zh-HK/docs/cli/release-notes.md
@@ -7,10 +7,12 @@ sidebar_icon: newspaper
 
 # Release Notes
 
-### v0.17.0
+### v0.16.3
 
 - **`auth` 子命令群組** — `longbridge auth login`、`auth logout`、`auth status`；`auth status` 本機查看 Token 有效性、到期時間、帳戶資訊和行情權限，無需網路
 - **`alert enable` / `alert disable`** — 切換到價提醒的啟用狀態，無需刪除重建
+- **修正：美股指數 symbol** — `.DJI.US`、`.VIX.US` 等美股指數 symbol 現已正確解析；美股指數需要前置點號（如 `.DJI.US`，而非 `DJI.US`）
+- **「您是否想查詢…」提示** — 查詢無結果時，CLI 會提示正確的 symbol 格式：缺少市場後綴 → `TSLA.US` / `700.HK`；缺少前置點號 → `.DJI.US`
 
 ### v0.16.1
 


### PR DESCRIPTION
## Summary

- Rename incorrectly labeled `v0.17.0` entry to `v0.16.3` in `release-notes.md` and `changelog.md` (all 3 locales: en / zh-CN / zh-HK)
- Update changelog date from `2026-04-15` to `2026-04-16`
- Add v0.16.3 new content from [longbridge/longbridge-terminal#114](https://github.com/longbridge/longbridge-terminal/pull/114):
  - Fix: US index symbols (`.DJI.US`, `.VIX.US`) now parse correctly
  - "Did you mean?" hints when a query returns no data

## Test plan

- [ ] Release Notes page shows `v0.16.3` (not `v0.17.0`) as the latest entry
- [ ] Changelog shows `2026-04-16 / CLI v0.16.3` with all 4 bullet points
- [ ] All 3 locales consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)