### PR TITLE
docs(cli): add v0.17.1 release notes

### DIFF
--- a/docs/en/docs/changelog.md
+++ b/docs/en/docs/changelog.md
@@ -6,6 +6,13 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-04-20
+
+### CLI v0.17.1
+
+- **`completion` command** — shell tab-completion for bash, zsh, fish, elvish, and powershell
+- Sets `User-Agent: longbridge-cli/<version>` and adds `x-cli-cmd` header on all API requests
+
 ## 2026-04-17
 
 ### CLI v0.17.0

--- a/docs/en/docs/cli/release-notes.md
+++ b/docs/en/docs/cli/release-notes.md
@@ -7,6 +7,12 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.17.1](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.1)
+
+- **`completion` command** — generate shell tab-completion scripts for bash, zsh, fish, elvish, and powershell; redirect stdout to the appropriate file then reload your shell to activate (e.g. `longbridge completion zsh > ~/.zfunc/_longbridge`)
+- Sets `User-Agent: longbridge-cli/<version>` on all HTTP and WebSocket requests
+- Adds `x-cli-cmd` request header identifying the active subcommand on every API call
+
 ### [v0.17.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.0)
 
 - **`dca` command** — recurring investment plans: create, update, pause, resume, stop, view trade history, stats summary, check symbol eligibility, and calculate next trade date; HK/SG accounts must agree to Terms and Conditions before creating a plan (`--agree-terms` to skip the interactive prompt)

--- a/docs/zh-CN/docs/changelog.md
+++ b/docs/zh-CN/docs/changelog.md
@@ -6,6 +6,13 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-04-20
+
+### CLI v0.17.1
+
+- **`completion` 命令** — 支持 bash、zsh、fish、elvish、powershell 的 Tab 补全
+- 所有 API 请求统一设置 `User-Agent: longbridge-cli/<version>` 并新增 `x-cli-cmd` 请求头
+
 ## 2026-04-17
 
 ### CLI v0.17.0

--- a/docs/zh-CN/docs/cli/release-notes.md
+++ b/docs/zh-CN/docs/cli/release-notes.md
@@ -7,6 +7,12 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.17.1](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.1)
+
+- **`completion` 命令** — 生成 bash、zsh、fish、elvish、powershell 的 Tab 补全脚本；将输出重定向到对应文件并重载 shell 即可启用（如 `longbridge completion zsh > ~/.zfunc/_longbridge`）
+- 所有 HTTP 及 WebSocket 请求统一设置 `User-Agent: longbridge-cli/<version>`
+- 每次 API 调用新增 `x-cli-cmd` 请求头，标识当前执行的子命令
+
 ### [v0.17.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.0)
 
 - **`dca` 命令** — 定投完整生命周期管理：创建、更新、暂停、恢复、停止、查看交易历史、统计概览、检查标的是否支持定投、计算下次交易日；港股及新加坡账户创建计划前须同意条款与条件（`--agree-terms` 可跳过交互提示）

--- a/docs/zh-HK/docs/changelog.md
+++ b/docs/zh-HK/docs/changelog.md
@@ -6,6 +6,13 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-04-20
+
+### CLI v0.17.1
+
+- **`completion` 指令** — 支援 bash、zsh、fish、elvish、powershell 的 Tab 補全
+- 所有 API 請求統一設定 `User-Agent: longbridge-cli/<version>` 並新增 `x-cli-cmd` 請求標頭
+
 ## 2026-04-17
 
 ### CLI v0.17.0

--- a/docs/zh-HK/docs/cli/release-notes.md
+++ b/docs/zh-HK/docs/cli/release-notes.md
@@ -7,6 +7,12 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.17.1](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.1)
+
+- **`completion` 指令** — 生成 bash、zsh、fish、elvish、powershell 的 Tab 補全腳本；將輸出重導向至對應檔案並重載 shell 即可啟用（如 `longbridge completion zsh > ~/.zfunc/_longbridge`）
+- 所有 HTTP 及 WebSocket 請求統一設定 `User-Agent: longbridge-cli/<version>`
+- 每次 API 呼叫新增 `x-cli-cmd` 請求標頭，標識當前執行的子指令
+
 ### [v0.17.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.0)
 
 - **`dca` 指令** — 定期定額完整生命週期管理：建立、更新、暫停、恢復、停止、查看交易記錄、統計概覽、確認標的是否支援定投、計算下次交易日；港股及新加坡帳戶建立計劃前須同意條款與條件（`--agree-terms` 可跳過互動提示）


### PR DESCRIPTION
## Summary

- Add CLI v0.17.1 release notes to changelog and release-notes pages (en, zh-CN, zh-HK)
- Update `longbridge-terminal` submodule to v0.17.1
- Documents `completion` command for shell tab-completion (bash/zsh/fish/elvish/powershell)
- Documents new `User-Agent` and `x-cli-cmd` request headers

## Test plan

- [ ] Verify release notes render correctly in all three language versions
- [ ] Check changelog entries are correctly dated (2026-04-20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)