### PR TITLE
docs(cli): add v0.17.3 release notes

### DIFF
--- a/docs/en/docs/changelog.md
+++ b/docs/en/docs/changelog.md
@@ -6,6 +6,14 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-04-22
+
+### CLI v0.17.3
+
+- **Fix: token refresh hang** — expired access token on a flaky network now fails immediately with a clear error; token file preserved for next retry
+- **`auth status`** — now shows three states: `valid` / `refresh pending` (auto-refreshes) / `expired` (was two states, `refresh pending` previously shown as `expired`)
+- **Fix: `--auth-code` login + Windows browser URL** — browser OAuth flow fixed when no token exists; Windows URL truncation on `&` parameters fixed
+
 ## 2026-04-20
 
 ### CLI v0.17.1

--- a/docs/en/docs/cli/release-notes.md
+++ b/docs/en/docs/cli/release-notes.md
@@ -7,6 +7,13 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.17.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.3)
+
+- **Fix: token refresh hang** — when the access token expired on a flaky network, the CLI no longer waits 5 minutes before failing; it now fails immediately with a clear error and preserves the token file for the next retry
+- **`auth status` accuracy** — now shows three states: `valid` (green), `refresh pending` (yellow, access token expired but refresh token valid — next command auto-refreshes with no user action needed), `expired` (red, re-login required); previously `refresh pending` was incorrectly shown as `expired`
+- **Fix: `--auth-code` login** — browser OAuth flow now triggers correctly when no token file exists
+- **Fix: Windows browser launch** — OAuth URLs containing `&` parameters no longer get truncated on Windows; switched to the `open` crate for cross-platform browser launching
+
 ### [v0.17.1](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.1)
 
 - **`completion` command** — generate shell tab-completion scripts for bash, zsh, fish, elvish, and powershell; redirect stdout to the appropriate file then reload your shell to activate (e.g. `longbridge completion zsh > ~/.zfunc/_longbridge`)

--- a/docs/zh-CN/docs/changelog.md
+++ b/docs/zh-CN/docs/changelog.md
@@ -6,6 +6,14 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-04-22
+
+### CLI v0.17.3
+
+- **修复：Token 刷新卡死** — 访问令牌过期且网络不稳定时立即报错，Token 文件保留供下次重试
+- **`auth status`** — 新增三态显示：`valid` / `refresh pending`（自动刷新）/ `expired`（之前 `refresh pending` 误显为 `expired`）
+- **修复：`--auth-code` 登录 + Windows 浏览器 URL** — 修复无 Token 文件时 OAuth 流程不触发及 Windows 上 URL `&` 参数被截断的问题
+
 ## 2026-04-20
 
 ### CLI v0.17.1

--- a/docs/zh-CN/docs/cli/release-notes.md
+++ b/docs/zh-CN/docs/cli/release-notes.md
@@ -7,6 +7,13 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.17.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.3)
+
+- **修复：Token 刷新卡死** — 当访问令牌过期且网络不稳定时，CLI 不再等待 5 分钟才报错，现在立即失败并给出明确提示，同时保留 Token 文件供下次重试
+- **`auth status` 准确性改进** — 现在显示三种状态：`valid`（绿色）、`refresh pending`（黄色，访问令牌已过期但刷新令牌有效，下次命令自动刷新无需操作）、`expired`（红色，需重新登录）；之前 `refresh pending` 状态被错误显示为 `expired`
+- **修复：`--auth-code` 登录** — 在没有 Token 文件时，浏览器 OAuth 流程现在可以正常触发
+- **修复：Windows 浏览器启动** — 包含 `&` 参数的 OAuth URL 不再在 Windows 上被截断；改用 `open` crate 实现跨平台浏览器调用
+
 ### [v0.17.1](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.1)
 
 - **`completion` 命令** — 生成 bash、zsh、fish、elvish、powershell 的 Tab 补全脚本；将输出重定向到对应文件并重载 shell 即可启用（如 `longbridge completion zsh > ~/.zfunc/_longbridge`）

--- a/docs/zh-HK/docs/changelog.md
+++ b/docs/zh-HK/docs/changelog.md
@@ -6,6 +6,14 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-04-22
+
+### CLI v0.17.3
+
+- **修復：Token 刷新卡死** — 存取令牌過期且網路不穩定時立即報錯，Token 檔案保留供下次重試
+- **`auth status`** — 新增三態顯示：`valid` / `refresh pending`（自動刷新）/ `expired`（之前 `refresh pending` 誤顯為 `expired`）
+- **修復：`--auth-code` 登入 + Windows 瀏覽器 URL** — 修復無 Token 檔案時 OAuth 流程不觸發及 Windows 上 URL `&` 參數被截斷的問題
+
 ## 2026-04-20
 
 ### CLI v0.17.1

--- a/docs/zh-HK/docs/cli/release-notes.md
+++ b/docs/zh-HK/docs/cli/release-notes.md
@@ -7,6 +7,13 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.17.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.3)
+
+- **修復：Token 刷新卡死** — 當存取令牌過期且網路不穩定時，CLI 不再等待 5 分鐘才報錯，現在立即失敗並給出明確提示，同時保留 Token 檔案供下次重試
+- **`auth status` 準確性改進** — 現在顯示三種狀態：`valid`（綠色）、`refresh pending`（黃色，存取令牌已過期但刷新令牌有效，下次指令自動刷新無需操作）、`expired`（紅色，需重新登入）；之前 `refresh pending` 狀態被錯誤顯示為 `expired`
+- **修復：`--auth-code` 登入** — 在沒有 Token 檔案時，瀏覽器 OAuth 流程現在可以正常觸發
+- **修復：Windows 瀏覽器啟動** — 包含 `&` 參數的 OAuth URL 不再在 Windows 上被截斷；改用 `open` crate 實現跨平台瀏覽器呼叫
+
 ### [v0.17.1](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.1)
 
 - **`completion` 指令** — 生成 bash、zsh、fish、elvish、powershell 的 Tab 補全腳本；將輸出重導向至對應檔案並重載 shell 即可啟用（如 `longbridge completion zsh > ~/.zfunc/_longbridge`）


### PR DESCRIPTION
## Summary

- Add v0.17.3 release notes to `release-notes.md` and `changelog.md` (en / zh-CN / zh-HK)
- Covers: token refresh hang fix, `auth status` three-state display, `--auth-code` login fix, Windows browser URL fix
- Based on PRs: longbridge/longbridge-terminal#134, #136, #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)