### PR TITLE
feat(nav): reorder top nav — Docs after MCP

### DIFF
--- a/docs/.vitepress/locales/en/nav.ts
+++ b/docs/.vitepress/locales/en/nav.ts
@@ -5,9 +5,9 @@ export const nav = (): DefaultTheme.NavItem[] => {
   return filterNavItems([
     { text: 'Home', link: '/', activeMatch: '^(/en)?/$' },
     { text: 'Skill', link: '/skill', activeMatch: '^(/en)?/skill' },
-    { text: 'Docs', link: '/docs', activeMatch: '^(/en)?/docs(?!/cli)(?!/api)(?!/mcp)' },
     { text: 'CLI', link: '/docs/cli', activeMatch: '^(/en)?/docs/cli' },
     { text: 'MCP', link: '/docs/mcp', activeMatch: '^(/en)?/docs/mcp' },
+    { text: 'Docs', link: '/docs', activeMatch: '^(/en)?/docs(?!/cli)(?!/api)(?!/mcp)' },
     { text: 'API Reference', link: '/docs/api', activeMatch: '^(/en)?/docs/api' },
     { text: 'SDK', link: '/sdk', activeMatch: '^(/en)?/sdk' },
     { text: 'Feedback', link: 'https://github.com/longbridge/developers/issues', target: '_blank' },

--- a/docs/.vitepress/locales/zh-CN/nav.ts
+++ b/docs/.vitepress/locales/zh-CN/nav.ts
@@ -5,9 +5,9 @@ export const nav = (lang: string): DefaultTheme.NavItem[] => {
   return filterNavItems([
     { text: '首页', link: `/${lang}/`, activeMatch: `^/${lang}/$` },
     { text: 'Skill', link: `/${lang}/skill`, activeMatch: `^/${lang}/skill` },
-    { text: '文档', link: `/${lang}/docs`, activeMatch: `^/${lang}/docs(?!/cli)(?!/api)(?!/mcp)` },
     { text: 'CLI', link: `/${lang}/docs/cli`, activeMatch: `^/${lang}/docs/cli` },
     { text: 'MCP', link: `/${lang}/docs/mcp`, activeMatch: `^/${lang}/docs/mcp` },
+    { text: '文档', link: `/${lang}/docs`, activeMatch: `^/${lang}/docs(?!/cli)(?!/api)(?!/mcp)` },
     { text: 'API 参考', link: `/${lang}/docs/api`, activeMatch: `^/${lang}/docs/api` },
     { text: 'SDK', link: `/${lang}/sdk`, activeMatch: `^/${lang}/sdk` },
     { text: 'Feedback', link: 'https://github.com/longbridge/developers/issues', target: '_blank' },

--- a/docs/.vitepress/locales/zh-HK/nav.ts
+++ b/docs/.vitepress/locales/zh-HK/nav.ts
@@ -5,9 +5,9 @@ export const nav = (lang: string): DefaultTheme.NavItem[] => {
   return filterNavItems([
     { text: '首頁', link: `/${lang}/`, activeMatch: `^/${lang}/$` },
     { text: 'Skill', link: `/${lang}/skill`, activeMatch: `^/${lang}/skill` },
-    { text: '文檔', link: `/${lang}/docs`, activeMatch: `^/${lang}/docs(?!/cli)(?!/api)(?!/mcp)` },
     { text: 'CLI', link: `/${lang}/docs/cli`, activeMatch: `^/${lang}/docs/cli` },
     { text: 'MCP', link: `/${lang}/docs/mcp`, activeMatch: `^/${lang}/docs/mcp` },
+    { text: '文檔', link: `/${lang}/docs`, activeMatch: `^/${lang}/docs(?!/cli)(?!/api)(?!/mcp)` },
     { text: 'API 參考', link: `/${lang}/docs/api`, activeMatch: `^/${lang}/docs/api` },
     { text: 'SDK', link: `/${lang}/sdk`, activeMatch: `^/${lang}/sdk` },
     { text: 'Feedback', link: 'https://github.com/longbridge/developers/issues', target: '_blank' },


### PR DESCRIPTION
## Summary

Top nav order changes:

Before: `Home · Skill · Docs · CLI · MCP · API Reference · SDK · Feedback`
After:  `Home · Skill · CLI · MCP · Docs · API Reference · SDK · Feedback`

Synced across `en` / `zh-CN` / `zh-HK`.