### PR TITLE
docs(cli): Note --limit alias for all --count parameters

### DIFF
--- a/skills/longbridge/references/cli/overview.md
+++ b/skills/longbridge/references/cli/overview.md
@@ -92,6 +92,10 @@ longbridge orders --format json | jq '.[] | select(.status == "New")'
 
 ## AI Agent Integration
 
+### Count / limit alias
+
+All commands with a `--count` flag also accept `--limit` as an alias. Both are equivalent — use whichever feels natural in generated commands.
+
 ### Parallel execution pattern
 
 Use `&` and `wait` to run multiple queries concurrently (faster results):


### PR DESCRIPTION
## Task #12 — 为所有带有 --count 参数的命令，增加 --limit 支持，以增强 AI 调用的容错性

Auto-generated by Endless workspace.

Phase: `dev`