### PR TITLE
fix(docs): correct broken /socket/* and /mcp links

### DIFF
--- a/docs/.vitepress/theme/components/ApiReference.vue
+++ b/docs/.vitepress/theme/components/ApiReference.vue
@@ -16,6 +16,21 @@ const md = new MarkdownIt({
 })
 const isZh = computed(() => locale.value.startsWith('zh'))
 
+// Rewrite absolute /docs/ links so zh-CN / zh-HK readers stay in their locale.
+// openapi.yaml shares a single Chinese content pool across both zh sites, so
+// baked-in locale prefixes would send zh-HK users to zh-CN (or vice versa);
+// we inject the prefix at render time based on the active locale instead.
+const localePrefix = computed(() => {
+  const l = locale.value
+  if (l.startsWith('zh-CN') || l === 'zh-Hans') return '/zh-CN'
+  if (l.startsWith('zh-HK') || l === 'zh-Hant') return '/zh-HK'
+  return ''
+})
+function localizeDocLinks(markdown: string): string {
+  if (!localePrefix.value) return markdown
+  return markdown.replace(/\]\(\/docs\//g, `](${localePrefix.value}/docs/`)
+}
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 interface Parameter {
@@ -407,7 +422,7 @@ const selectedPageHtml = computed(() => {
   const page = selectedPage.value
   if (!page) return ''
   const content = isZh.value && page.contentZh ? page.contentZh : page.content
-  return content ? md.render(content) : ''
+  return content ? md.render(localizeDocLinks(content)) : ''
 })
 
 const selectedSections = computed((): Section[] => {

--- a/docs/en/docs/qa/general.md
+++ b/docs/en/docs/qa/general.md
@@ -56,6 +56,6 @@ longbridge static NVDA.US
 
 **MCP (AI Tool Integration)**
 
-If you use AI tools like Claude, Cursor, or ChatGPT, connect the [Longbridge MCP service](/mcp). Once configured, simply ask in plain language and the AI will query market data on your behalf.
+If you use AI tools like Claude, Cursor, or ChatGPT, connect the [Longbridge MCP service](/docs/mcp). Once configured, simply ask in plain language and the AI will query market data on your behalf.
 
 Both methods require a Longbridge account.

--- a/docs/zh-CN/docs/qa/general.md
+++ b/docs/zh-CN/docs/qa/general.md
@@ -56,6 +56,6 @@ longbridge static NVDA.US
 
 **MCP（AI 工具集成）**
 
-如果你日常使用 Claude、Cursor、ChatGPT 等 AI 工具，可以接入 [Longbridge MCP 服务](/mcp)，配置完成后直接用自然语言向 AI 提问，由 AI 代你调用行情接口获取数据。
+如果你日常使用 Claude、Cursor、ChatGPT 等 AI 工具，可以接入 [Longbridge MCP 服务](/zh-CN/docs/mcp)，配置完成后直接用自然语言向 AI 提问，由 AI 代你调用行情接口获取数据。
 
 两种方式均需拥有 Longbridge 账户。

--- a/docs/zh-HK/docs/qa/general.md
+++ b/docs/zh-HK/docs/qa/general.md
@@ -56,6 +56,6 @@ longbridge static NVDA.US
 
 **MCP（AI 工具整合）**
 
-如果你日常使用 Claude、Cursor、ChatGPT 等 AI 工具，可以接入 [Longbridge MCP 服務](/mcp)，設定完成後直接用自然語言向 AI 提問，由 AI 代你呼叫行情介面取得數據。
+如果你日常使用 Claude、Cursor、ChatGPT 等 AI 工具，可以接入 [Longbridge MCP 服務](/zh-HK/docs/mcp)，設定完成後直接用自然語言向 AI 提問，由 AI 代你呼叫行情介面取得數據。
 
 兩種方式均需擁有 Longbridge 帳戶。

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -370,7 +370,7 @@ x-pages:
     x-title-zh: 实时行情
     x-icon: activity
     content: |
-      > **Note:** Real-time market data is **not** part of this HTTP REST API. Quotes, price feeds, order book depth, broker queues, and trade ticks are delivered via **WebSocket / TCP long connection** through a dedicated quote gateway — see the [Socket Feed](/socket/hosts) documentation.
+      > **Note:** Real-time market data is **not** part of this HTTP REST API. Quotes, price feeds, order book depth, broker queues, and trade ticks are delivered via **WebSocket / TCP long connection** through a dedicated quote gateway — see the [Socket Feed](/docs/socket/hosts) documentation.
 
       ## Overview
 
@@ -399,11 +399,11 @@ x-pages:
 
       ## Further Reading
 
-      - [Socket Feed endpoints](/socket/hosts)
-      - [Subscribe to market data](/socket/subscribe_quote)
-      - [Protocol overview](/socket/protocol/overview)
+      - [Socket Feed endpoints](/docs/socket/hosts)
+      - [Subscribe to market data](/docs/socket/subscribe_quote)
+      - [Protocol overview](/docs/socket/protocol/overview)
     x-content-zh: |
-      > **注意：** 实时行情数据**不**属于本 HTTP REST API 的范围。报价、价格推送、盘口、经纪队列及成交明细通过专用行情网关以 **WebSocket / TCP 长连接**方式推送，详见 [Socket 实时推送](/socket/hosts) 文档。
+      > **注意：** 实时行情数据**不**属于本 HTTP REST API 的范围。报价、价格推送、盘口、经纪队列及成交明细通过专用行情网关以 **WebSocket / TCP 长连接**方式推送，详见 [Socket 实时推送](/docs/socket/hosts) 文档。
 
       ## 概述
 
@@ -432,9 +432,9 @@ x-pages:
 
       ## 相关文档
 
-      - [Socket 实时推送接入地址](/socket/hosts)
-      - [订阅行情推送](/socket/subscribe_quote)
-      - [协议概览](/socket/protocol/overview)
+      - [Socket 实时推送接入地址](/docs/socket/hosts)
+      - [订阅行情推送](/docs/socket/subscribe_quote)
+      - [协议概览](/docs/socket/protocol/overview)
   - id: error-codes
     title: Error Codes
     x-title-zh: 错误码


### PR DESCRIPTION
## Summary

- "Socket Feed" / "相关文档" links in the REST API overview no longer 404 — paths corrected to `/docs/socket/xxx`
- Restored the inline "see the Socket Feed documentation" reference in the Real-Time Market Data note
- FAQ's "Longbridge MCP service" link now works (`/mcp` → `/docs/mcp`)
- Readers on zh-CN / zh-HK sites stay in their own locale when clicking into `/docs/*` targets inside OpenAPI content