### PR TITLE
docs(cli): add v0.17.4 release notes

### DIFF
--- a/docs/en/docs/changelog.md
+++ b/docs/en/docs/changelog.md
@@ -11,7 +11,6 @@ sidebar_icon: newspaper
 ### CLI v0.17.4
 
 - **`--limit` alias** — all `--count` parameters now accept `--limit` as an alias (AI agent tool-calling compatibility)
-- **JSON output cleanup** — `--format json` no longer emits the `aaid` field from account/asset commands
 - **Fix: Unix self-update** — `longbridge update` no longer fails with ETXTBUSY on Unix
 
 ## 2026-04-22

--- a/docs/en/docs/changelog.md
+++ b/docs/en/docs/changelog.md
@@ -6,6 +6,14 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-04-24
+
+### CLI v0.17.4
+
+- **`--limit` alias** — all `--count` parameters now accept `--limit` as an alias (AI agent tool-calling compatibility)
+- **JSON output cleanup** — `--format json` no longer emits the `aaid` field from account/asset commands
+- **Fix: Unix self-update** — `longbridge update` no longer fails with ETXTBUSY on Unix
+
 ## 2026-04-22
 
 ### CLI v0.17.3

--- a/docs/en/docs/cli/release-notes.md
+++ b/docs/en/docs/cli/release-notes.md
@@ -10,7 +10,6 @@ sidebar_icon: newspaper
 ### [v0.17.4](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.4)
 
 - **`--limit` alias for `--count`** — all commands that accept `--count` now also accept `--limit` as an alias, improving compatibility for AI agent tool-calling
-- **JSON output: strip non-public fields** — `--format json` no longer emits the `aaid` field; affects `exchange-rate`, `profit-analysis`, `portfolio`, and other account/asset commands
 - **Fix: Unix self-update ETXTBUSY** — `longbridge update` no longer fails with "Text file busy" on Unix; the update now uses a staged temp file and atomic rename instead of writing directly to the running binary
 
 ### [v0.17.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.3)

--- a/docs/en/docs/cli/release-notes.md
+++ b/docs/en/docs/cli/release-notes.md
@@ -7,6 +7,12 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.17.4](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.4)
+
+- **`--limit` alias for `--count`** — all commands that accept `--count` now also accept `--limit` as an alias, improving compatibility for AI agent tool-calling
+- **JSON output: strip non-public fields** — `--format json` no longer emits the `aaid` field; affects `exchange-rate`, `profit-analysis`, `portfolio`, and other account/asset commands
+- **Fix: Unix self-update ETXTBUSY** — `longbridge update` no longer fails with "Text file busy" on Unix; the update now uses a staged temp file and atomic rename instead of writing directly to the running binary
+
 ### [v0.17.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.3)
 
 - **Fix: token refresh hang** — when the access token expired on a flaky network, the CLI no longer waits 5 minutes before failing; it now fails immediately with a clear error and preserves the token file for the next retry

--- a/docs/zh-CN/docs/changelog.md
+++ b/docs/zh-CN/docs/changelog.md
@@ -6,6 +6,14 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-04-24
+
+### CLI v0.17.4
+
+- **`--limit` 别名** — 所有 `--count` 参数现支持 `--limit` 别名（改善 AI agent 工具调用兼容性）
+- **JSON 输出清理** — `--format json` 不再输出账户/资产命令中的 `aaid` 字段
+- **修复：Unix 自更新** — `longbridge update` 在 Unix 上不再出现 ETXTBUSY 错误
+
 ## 2026-04-22
 
 ### CLI v0.17.3

--- a/docs/zh-CN/docs/changelog.md
+++ b/docs/zh-CN/docs/changelog.md
@@ -11,7 +11,6 @@ sidebar_icon: newspaper
 ### CLI v0.17.4
 
 - **`--limit` 别名** — 所有 `--count` 参数现支持 `--limit` 别名（改善 AI agent 工具调用兼容性）
-- **JSON 输出清理** — `--format json` 不再输出账户/资产命令中的 `aaid` 字段
 - **修复：Unix 自更新** — `longbridge update` 在 Unix 上不再出现 ETXTBUSY 错误
 
 ## 2026-04-22

--- a/docs/zh-CN/docs/cli/release-notes.md
+++ b/docs/zh-CN/docs/cli/release-notes.md
@@ -7,6 +7,12 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.17.4](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.4)
+
+- **`--limit` 别名** — 所有接受 `--count` 参数的命令现在也支持 `--limit` 作为别名，提升 AI agent 工具调用兼容性
+- **JSON 输出清理** — `--format json` 不再输出 `aaid` 字段；影响 `exchange-rate`、`profit-analysis`、`portfolio` 等账户/资产类命令
+- **修复：Unix 自更新 ETXTBUSY** — `longbridge update` 在 Unix 上不再因"Text file busy"报错；更新流程改为先写入临时文件再原子重命名，不再直接写入正在运行的二进制文件
+
 ### [v0.17.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.3)
 
 - **修复：Token 刷新卡死** — 当访问令牌过期且网络不稳定时，CLI 不再等待 5 分钟才报错，现在立即失败并给出明确提示，同时保留 Token 文件供下次重试

--- a/docs/zh-CN/docs/cli/release-notes.md
+++ b/docs/zh-CN/docs/cli/release-notes.md
@@ -10,7 +10,6 @@ sidebar_icon: newspaper
 ### [v0.17.4](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.4)
 
 - **`--limit` 别名** — 所有接受 `--count` 参数的命令现在也支持 `--limit` 作为别名，提升 AI agent 工具调用兼容性
-- **JSON 输出清理** — `--format json` 不再输出 `aaid` 字段；影响 `exchange-rate`、`profit-analysis`、`portfolio` 等账户/资产类命令
 - **修复：Unix 自更新 ETXTBUSY** — `longbridge update` 在 Unix 上不再因"Text file busy"报错；更新流程改为先写入临时文件再原子重命名，不再直接写入正在运行的二进制文件
 
 ### [v0.17.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.3)

--- a/docs/zh-HK/docs/changelog.md
+++ b/docs/zh-HK/docs/changelog.md
@@ -6,6 +6,14 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-04-24
+
+### CLI v0.17.4
+
+- **`--limit` 別名** — 所有 `--count` 參數現支援 `--limit` 別名（改善 AI agent 工具呼叫相容性）
+- **JSON 輸出清理** — `--format json` 不再輸出帳戶/資產指令中的 `aaid` 欄位
+- **修復：Unix 自更新** — `longbridge update` 在 Unix 上不再出現 ETXTBUSY 錯誤
+
 ## 2026-04-22
 
 ### CLI v0.17.3

--- a/docs/zh-HK/docs/changelog.md
+++ b/docs/zh-HK/docs/changelog.md
@@ -11,7 +11,6 @@ sidebar_icon: newspaper
 ### CLI v0.17.4
 
 - **`--limit` 別名** — 所有 `--count` 參數現支援 `--limit` 別名（改善 AI agent 工具呼叫相容性）
-- **JSON 輸出清理** — `--format json` 不再輸出帳戶/資產指令中的 `aaid` 欄位
 - **修復：Unix 自更新** — `longbridge update` 在 Unix 上不再出現 ETXTBUSY 錯誤
 
 ## 2026-04-22

--- a/docs/zh-HK/docs/cli/release-notes.md
+++ b/docs/zh-HK/docs/cli/release-notes.md
@@ -10,7 +10,6 @@ sidebar_icon: newspaper
 ### [v0.17.4](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.4)
 
 - **`--limit` 別名** — 所有接受 `--count` 參數的指令現在也支援 `--limit` 作為別名，提升 AI agent 工具呼叫相容性
-- **JSON 輸出清理** — `--format json` 不再輸出 `aaid` 欄位；影響 `exchange-rate`、`profit-analysis`、`portfolio` 等帳戶/資產類指令
 - **修復：Unix 自更新 ETXTBUSY** — `longbridge update` 在 Unix 上不再因「Text file busy」報錯；更新流程改為先寫入暫存檔再原子重新命名，不再直接寫入正在執行中的二進位檔案
 
 ### [v0.17.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.3)

--- a/docs/zh-HK/docs/cli/release-notes.md
+++ b/docs/zh-HK/docs/cli/release-notes.md
@@ -7,6 +7,12 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.17.4](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.4)
+
+- **`--limit` 別名** — 所有接受 `--count` 參數的指令現在也支援 `--limit` 作為別名，提升 AI agent 工具呼叫相容性
+- **JSON 輸出清理** — `--format json` 不再輸出 `aaid` 欄位；影響 `exchange-rate`、`profit-analysis`、`portfolio` 等帳戶/資產類指令
+- **修復：Unix 自更新 ETXTBUSY** — `longbridge update` 在 Unix 上不再因「Text file busy」報錯；更新流程改為先寫入暫存檔再原子重新命名，不再直接寫入正在執行中的二進位檔案
+
 ### [v0.17.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.17.3)
 
 - **修復：Token 刷新卡死** — 當存取令牌過期且網路不穩定時，CLI 不再等待 5 分鐘才報錯，現在立即失敗並給出明確提示，同時保留 Token 檔案供下次重試


### PR DESCRIPTION
## Task #14 — CLI 的 v0.17.4 已经打包好了，更新 developers 项目，增加 Release Notes

🤖 Auto-generated by Endless.

Phase: `dev`