### PR TITLE
fix(quant): fix routing, nav, footer, sidebar icon & Dashboard link

### DIFF
--- a/docs/.vitepress/locales/en/index.ts
+++ b/docs/.vitepress/locales/en/index.ts
@@ -57,5 +57,6 @@ export const enConfig: LocaleSpecificConfig<DefaultTheme.Config> = {
     lightModeSwitchTitle: 'Switch to Light Mode',
     darkModeSwitchTitle: 'Switch to Dark Mode',
     skipToContentLabel: 'Skip to Content',
+
   },
 }

--- a/docs/.vitepress/locales/en/nav.ts
+++ b/docs/.vitepress/locales/en/nav.ts
@@ -10,6 +10,5 @@ export const nav = (): DefaultTheme.NavItem[] => {
     { text: 'Docs', link: '/docs', activeMatch: '^(/en)?/docs(?!/cli)(?!/api)(?!/mcp)' },
     { text: 'API Reference', link: '/docs/api', activeMatch: '^(/en)?/docs/api' },
     { text: 'SDK', link: '/sdk', activeMatch: '^(/en)?/sdk' },
-    { text: 'Feedback', link: 'https://github.com/longbridge/developers/issues', target: '_blank' },
   ])
 }

--- a/docs/.vitepress/locales/zh-CN/index.ts
+++ b/docs/.vitepress/locales/zh-CN/index.ts
@@ -55,5 +55,6 @@ export const zhCNConfig: LocaleSpecificConfig<DefaultTheme.Config> = {
     lightModeSwitchTitle: '切换到浅色模式',
     darkModeSwitchTitle: '切换到深色模式',
     skipToContentLabel: '跳转到内容',
+
   },
 }

--- a/docs/.vitepress/locales/zh-CN/nav.ts
+++ b/docs/.vitepress/locales/zh-CN/nav.ts
@@ -10,6 +10,5 @@ export const nav = (lang: string): DefaultTheme.NavItem[] => {
     { text: '文档', link: `/${lang}/docs`, activeMatch: `^/${lang}/docs(?!/cli)(?!/api)(?!/mcp)` },
     { text: 'API 参考', link: `/${lang}/docs/api`, activeMatch: `^/${lang}/docs/api` },
     { text: 'SDK', link: `/${lang}/sdk`, activeMatch: `^/${lang}/sdk` },
-    { text: 'Feedback', link: 'https://github.com/longbridge/developers/issues', target: '_blank' },
   ])
 }

--- a/docs/.vitepress/locales/zh-HK/index.ts
+++ b/docs/.vitepress/locales/zh-HK/index.ts
@@ -56,5 +56,6 @@ export const zhHKConfig: LocaleSpecificConfig<DefaultTheme.Config> = {
     lightModeSwitchTitle: '切換到淺色模式',
     darkModeSwitchTitle: '切換到深色模式',
     skipToContentLabel: '跳轉到內容',
+
   },
 }

--- a/docs/.vitepress/locales/zh-HK/nav.ts
+++ b/docs/.vitepress/locales/zh-HK/nav.ts
@@ -10,6 +10,5 @@ export const nav = (lang: string): DefaultTheme.NavItem[] => {
     { text: '文檔', link: `/${lang}/docs`, activeMatch: `^/${lang}/docs(?!/cli)(?!/api)(?!/mcp)` },
     { text: 'API 參考', link: `/${lang}/docs/api`, activeMatch: `^/${lang}/docs/api` },
     { text: 'SDK', link: `/${lang}/sdk`, activeMatch: `^/${lang}/sdk` },
-    { text: 'Feedback', link: 'https://github.com/longbridge/developers/issues', target: '_blank' },
   ])
 }

--- a/docs/.vitepress/theme/components/DashboardNavLink.vue
+++ b/docs/.vitepress/theme/components/DashboardNavLink.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { localePath } from '../utils/i18n'
+
+const { t } = useI18n()
+const isLogin = ref(false)
+
+onMounted(() => {
+  isLogin.value = window.longportInternal.isLogin()
+})
+</script>
+
+<template>
+  <ClientOnly>
+    <a v-if="isLogin" :href="localePath('/account')" class="dashboard-nav-link">{{ t('HD2WD-CgkkcJJW12yOmDM') }}</a>
+  </ClientOnly>
+</template>
+
+<style scoped>
+.dashboard-nav-link {
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--vp-c-text-1);
+  text-decoration: none;
+  transition: color 0.25s;
+  white-space: nowrap;
+}
+
+.dashboard-nav-link:hover {
+  color: var(--vp-c-brand-1);
+}
+</style>

--- a/docs/.vitepress/theme/components/HomePage/Footer.vue
+++ b/docs/.vitepress/theme/components/HomePage/Footer.vue
@@ -68,6 +68,7 @@ const rightLinks = [
   { href: '/docs/mcp', label: 'MCP' },
   { href: '/docs/cli', label: 'CLI' },
   { href: '/docs/llm', label: 'LLM' },
+  { href: 'https://github.com/longbridge/developers/issues', label: 'Feedback' },
 ]
 </script>
 

--- a/docs/.vitepress/theme/layouts/Layout.vue
+++ b/docs/.vitepress/theme/layouts/Layout.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import UserAvatar from '../components/UserAvatar/index.vue'
+import DashboardNavLink from '../components/DashboardNavLink.vue'
 import Breadcrumb from '../components/Breadcrumb/index.vue'
 import Layout from './LayoutInner.vue'
 import { useI18nSync, useHighlighter, useLLMMarkdownLink } from '../composables'
@@ -14,6 +15,7 @@ const { llmMarkdownLink } = useLLMMarkdownLink()
 <template>
   <Layout>
     <template #nav-bar-content-after>
+      <DashboardNavLink />
       <UserAvatar />
     </template>
     <template #doc-top>

--- a/docs/.vitepress/theme/utils/gen.ts
+++ b/docs/.vitepress/theme/utils/gen.ts
@@ -24,6 +24,7 @@ const SIDEBAR_ICONS: Record<string, string> = {
   'arrow-down-to-line': `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17V3"/><path d="m6 11 6 6 6-6"/><path d="M19 21H5"/></svg>`,
   'badge-question-mark': `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" x2="12.01" y1="17" y2="17"/></svg>`,
   'square-terminal': `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 11 2-2-2-2"/><path d="M11 13h4"/><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/></svg>`,
+  'line-chart': `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg>`,
 }
 
 export const SIDEBAR_ICONS_MAP = SIDEBAR_ICONS
@@ -140,9 +141,11 @@ function generateSidebarItems(
 
       const normalizeLink =
         file === 'index.md' ? `${relativePath}.md` : path.join(relativePath, file.replace('.md', ''))
+      const docsBaseIdx = rootPath.indexOf('/docs')
+      const docsBase = docsBaseIdx >= 0 ? rootPath.slice(0, docsBaseIdx + 5) : rootPath
       const link = slug
         ? path.isAbsolute(slug)
-          ? path.join(rootPath, slug)
+          ? docsBase + slug
           : path.join(relativePath, slug)
         : normalizeLink
       const position = data['sidebar_position']

--- a/docs/en/docs/cli/quant/backtest.md
+++ b/docs/en/docs/cli/quant/backtest.md
@@ -1,7 +1,8 @@
 ---
 title: 'Backtest'
-sidebar_label: 'Backtest'
+sidebar_label: 'backtest'
 sidebar_position: 3
+slug: '/cli/quant/backtest'
 ---
 
 # Backtesting

--- a/docs/en/docs/cli/quant/index.md
+++ b/docs/en/docs/cli/quant/index.md
@@ -1,7 +1,8 @@
 ---
 title: 'quant run'
-sidebar_label: 'Overview'
+sidebar_label: 'overview'
 sidebar_position: 1
+slug: '/cli/quant'
 ---
 
 # longbridge quant run

--- a/docs/en/docs/cli/quant/indicator.md
+++ b/docs/en/docs/cli/quant/indicator.md
@@ -1,7 +1,8 @@
 ---
 title: 'Indicator'
-sidebar_label: 'Indicator'
+sidebar_label: 'indicator'
 sidebar_position: 2
+slug: '/cli/quant/indicator'
 ---
 
 # Indicators

--- a/docs/en/docs/cli/quant/screener.md
+++ b/docs/en/docs/cli/quant/screener.md
@@ -1,7 +1,8 @@
 ---
 title: 'Stock Screening'
-sidebar_label: 'Stock Screening'
+sidebar_label: 'screener'
 sidebar_position: 4
+slug: '/cli/quant/screener'
 ---
 
 # Stock Screening

--- a/docs/zh-CN/docs/cli/quant/backtest.md
+++ b/docs/zh-CN/docs/cli/quant/backtest.md
@@ -2,6 +2,7 @@
 title: '回测'
 sidebar_label: '回测'
 sidebar_position: 3
+slug: '/cli/quant/backtest'
 ---
 
 # 回测

--- a/docs/zh-CN/docs/cli/quant/index.md
+++ b/docs/zh-CN/docs/cli/quant/index.md
@@ -2,6 +2,7 @@
 title: 'quant run'
 sidebar_label: '概览'
 sidebar_position: 1
+slug: '/cli/quant'
 ---
 
 # longbridge quant run

--- a/docs/zh-CN/docs/cli/quant/indicator.md
+++ b/docs/zh-CN/docs/cli/quant/indicator.md
@@ -2,6 +2,7 @@
 title: '指标'
 sidebar_label: '指标'
 sidebar_position: 2
+slug: '/cli/quant/indicator'
 ---
 
 # 指标

--- a/docs/zh-CN/docs/cli/quant/screener.md
+++ b/docs/zh-CN/docs/cli/quant/screener.md
@@ -2,6 +2,7 @@
 title: '选股'
 sidebar_label: '选股'
 sidebar_position: 4
+slug: '/cli/quant/screener'
 ---
 
 # 选股

--- a/docs/zh-HK/docs/cli/quant/backtest.md
+++ b/docs/zh-HK/docs/cli/quant/backtest.md
@@ -2,6 +2,7 @@
 title: '回測'
 sidebar_label: '回測'
 sidebar_position: 3
+slug: '/cli/quant/backtest'
 ---
 
 # 回測

--- a/docs/zh-HK/docs/cli/quant/index.md
+++ b/docs/zh-HK/docs/cli/quant/index.md
@@ -2,6 +2,7 @@
 title: 'quant run'
 sidebar_label: '概覽'
 sidebar_position: 1
+slug: '/cli/quant'
 ---
 
 # longbridge quant run

--- a/docs/zh-HK/docs/cli/quant/indicator.md
+++ b/docs/zh-HK/docs/cli/quant/indicator.md
@@ -2,6 +2,7 @@
 title: '指標'
 sidebar_label: '指標'
 sidebar_position: 2
+slug: '/cli/quant/indicator'
 ---
 
 # 指標

--- a/docs/zh-HK/docs/cli/quant/screener.md
+++ b/docs/zh-HK/docs/cli/quant/screener.md
@@ -2,6 +2,7 @@
 title: '選股'
 sidebar_label: '選股'
 sidebar_position: 4
+slug: '/cli/quant/screener'
 ---
 
 # 選股


### PR DESCRIPTION
## Summary

- Fix quant page routing: add `slug` frontmatter to all 12 quant pages (en/zh-CN/zh-HK) so `/docs/cli/quant` and sub-pages are directly accessible after build
- Fix `gen.ts` absolute-slug sidebar link bug — `path.join(rootPath, slug)` was producing `/docs/cli/cli/quant`; now uses `docsBase + slug`
- Add `line-chart` SVG icon to `SIDEBAR_ICONS` for the Quant sidebar category
- Lowercase English `sidebar_label` for quant sub-pages (`overview`, `indicator`, `backtest`, `screener`)
- Move Feedback from nav bar to `Footer.vue` right-side links
- Add `DashboardNavLink.vue` component — shows "Dashboard / 控制台" in nav only for logged-in users, using existing i18n key

## Test plan

- [ ] Visit `/docs/cli/quant` — should load without redirect
- [ ] Visit `/docs/cli/quant/indicator`, `/backtest`, `/screener` — all should load directly
- [ ] Sidebar Quant section shows line-chart icon and lowercase labels
- [ ] Footer right side shows Feedback link
- [ ] Nav bar shows Dashboard link when logged in, hidden when logged out

🤖 Generated with [Claude Code](https://claude.com/claude-code)