### PR TITLE
feat(dev): add mock login toggle and shared login state

### DIFF
--- a/docs/.vitepress/theme/components/DashboardNavLink.vue
+++ b/docs/.vitepress/theme/components/DashboardNavLink.vue
@@ -1,33 +1,40 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { localePath } from '../utils/i18n'
+import { isLoginState } from '../composables/useLoginState'
 
 const { t } = useI18n()
-const isLogin = ref(false)
+const isLogin = isLoginState
 
-onMounted(() => {
-  isLogin.value = window.longportInternal.isLogin()
-})
+function navigate() {
+  window.location.href = localePath('/account')
+}
 </script>
 
 <template>
   <ClientOnly>
-    <a v-if="isLogin" :href="localePath('/account')" class="dashboard-nav-link">{{ t('HD2WD-CgkkcJJW12yOmDM') }}</a>
+    <div v-if="isLogin" class="dashboard-wrap mr-2 ml-6">
+      <a class="dashboard-nav-link" @click.prevent="navigate">{{ t('HD2WD-CgkkcJJW12yOmDM') }}</a>
+    </div>
   </ClientOnly>
 </template>
 
 <style scoped>
+.dashboard-wrap {
+  display: flex;
+  align-items: center;
+}
+
 .dashboard-nav-link {
   display: flex;
   align-items: center;
-  padding: 0 8px;
   font-size: 14px;
   font-weight: 500;
   color: var(--vp-c-text-1);
   text-decoration: none;
-  transition: color 0.25s;
+  cursor: pointer;
   white-space: nowrap;
+  transition: color 0.25s;
 }
 
 .dashboard-nav-link:hover {

--- a/docs/.vitepress/theme/components/MockLoginPanel.vue
+++ b/docs/.vitepress/theme/components/MockLoginPanel.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { isLoginState, toggleMockLogin } from '../composables/useLoginState'
+</script>
+
+<template>
+  <div class="mock-login-panel">
+    <button class="mock-btn" @click="toggleMockLogin">
+      {{ isLoginState ? '🔓 Mock Logout' : '🔐 Mock Login' }}
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.mock-login-panel {
+  position: fixed;
+  bottom: 16px;
+  left: 16px;
+  z-index: 9999;
+}
+
+.mock-btn {
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 6px;
+  border: 1px dashed var(--vp-c-brand-1);
+  background: var(--vp-c-bg);
+  color: var(--vp-c-brand-1);
+  cursor: pointer;
+  opacity: 0.8;
+  transition: opacity 0.2s;
+}
+
+.mock-btn:hover {
+  opacity: 1;
+}
+</style>

--- a/docs/.vitepress/theme/components/UserAvatar/index.vue
+++ b/docs/.vitepress/theme/components/UserAvatar/index.vue
@@ -7,6 +7,7 @@ import { localePath } from '../../utils/i18n'
 import { createLoginRedirectPath } from '../../utils/navigate'
 import { useI18n } from 'vue-i18n'
 import { useAvatar } from './uesAvatar'
+import { isLoginState, initLoginState } from '../../composables/useLoginState'
 import endsWith from 'lodash/endsWith'
 
 const { t } = useI18n()
@@ -15,12 +16,12 @@ const open = ref(false)
 const el = ref<HTMLElement>()
 const dropdownRef = ref<InstanceType<typeof Dropdown>>()
 const closeTimer = ref<NodeJS.Timeout | null>(null)
-const isLogin = ref(false)
+const isLogin = isLoginState
 
 onMounted(() => {
-  isLogin.value = window.longportInternal.isLogin()
+  initLoginState()
 
-  const isProd = !endsWith(location.hostname, '.xyz')
+  const isProd = !endsWith(location.hostname, '.xyz') && !import.meta.env.DEV
   const loginUrl = createLoginRedirectPath({
     sw_open: '1',
   })
@@ -127,15 +128,6 @@ onUnmounted(() => {
   margin-right: -8px;
 }
 
-@media (min-width: 768px) {
-  .VPFlyout::before {
-    margin: 0 16px;
-    width: 1px;
-    height: 24px;
-    background-color: var(--vp-c-divider);
-    content: '';
-  }
-}
 
 .VPFlyout:hover {
   color: var(--vp-c-brand-1);

--- a/docs/.vitepress/theme/composables/index.ts
+++ b/docs/.vitepress/theme/composables/index.ts
@@ -1,4 +1,5 @@
 export { useThemeToggle } from './useThemeToggle'
+export { isLoginState, initLoginState, toggleMockLogin } from './useLoginState'
 export { useI18nSync } from './useI18nSync'
 export { useHighlighter } from './useHighlighter'
 export { useLLMMarkdownLink } from './useLLMMarkdownLink'

--- a/docs/.vitepress/theme/composables/useLoginState.ts
+++ b/docs/.vitepress/theme/composables/useLoginState.ts
@@ -1,0 +1,18 @@
+import { ref } from 'vue'
+
+const MOCK_KEY = '__mock_login'
+
+export const isLoginState = ref(false)
+
+export function initLoginState() {
+  if (import.meta.env.DEV) {
+    isLoginState.value = localStorage.getItem(MOCK_KEY) === 'true'
+  } else {
+    isLoginState.value = window.longportInternal?.isLogin() ?? false
+  }
+}
+
+export function toggleMockLogin() {
+  isLoginState.value = !isLoginState.value
+  localStorage.setItem(MOCK_KEY, String(isLoginState.value))
+}

--- a/docs/.vitepress/theme/layouts/Layout.vue
+++ b/docs/.vitepress/theme/layouts/Layout.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import UserAvatar from '../components/UserAvatar/index.vue'
 import DashboardNavLink from '../components/DashboardNavLink.vue'
+import MockLoginPanel from '../components/MockLoginPanel.vue'
 import Breadcrumb from '../components/Breadcrumb/index.vue'
 import Layout from './LayoutInner.vue'
 import { useI18nSync, useHighlighter, useLLMMarkdownLink } from '../composables'
+
+const isDev = import.meta.env.DEV
 
 // 使用抽离的 hooks
 useI18nSync()
@@ -18,6 +21,10 @@ const { llmMarkdownLink } = useLLMMarkdownLink()
       <DashboardNavLink />
       <UserAvatar />
     </template>
+    <template #layout-bottom>
+      <MockLoginPanel v-if="isDev" />
+    </template>
+
     <template #doc-top>
       <div class="-mt-4">
         <Breadcrumb />


### PR DESCRIPTION
## Summary

- Add `useLoginState.ts` composable with module-level `isLoginState` ref shared across components
- `UserAvatar` and `DashboardNavLink` both use `isLoginState` — reactive to mock toggle without page reload
- Add `MockLoginPanel.vue` (dev-only, fixed bottom-left) to simulate login/logout state
- `DashboardNavLink` uses `window.location.href` to bypass VitePress router for `/account` navigation
- `initLoginState()` reads from `localStorage` in dev mode, `window.longportInternal.isLogin()` in prod

## Test plan

- [ ] In dev mode: Mock Login/Logout button appears at bottom-left
- [ ] Clicking toggles Dashboard link and Avatar/Login button reactively
- [ ] In prod build: MockLoginPanel is not included

🤖 Generated with [Claude Code](https://claude.com/claude-code)