### PR TITLE
docs(cli): add v0.19.2 release notes and update finance-calendar docs

### DIFF
--- a/docs/en/docs/changelog.md
+++ b/docs/en/docs/changelog.md
@@ -6,6 +6,14 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-05-05
+
+### CLI v0.19.2
+
+- **`finance-calendar` revamp** — restructured into subcommands: `report`, `dividend`, `split`, `ipo`, `macrodata`, `closed`; new `--filter watchlist|positions` scopes events to your watchlist or holdings
+- **TUI enhancements** — full mouse support; chart type toggle (line / candlestick) in stock detail view
+- **`quote`** — new "Last Chg%" column; `corp-action` defaults to 30 items with `--all` for full list; `update --force` skips version check
+
 ## 2026-04-30
 
 ### CLI v0.19.0

--- a/docs/en/docs/cli/fundamentals/finance-calendar.md
+++ b/docs/en/docs/cli/fundamentals/finance-calendar.md
@@ -6,37 +6,52 @@ sidebar_position: 6
 
 # longbridge finance-calendar
 
-Browse upcoming financial events — earnings reports, dividend payments, IPOs, and macroeconomic releases — filtered by symbol, market, or event type.
+Browse upcoming financial events — earnings reports, dividend payments, stock splits, IPOs, and macroeconomic releases — filtered by symbol, watchlist, market, or event type.
 
-## Basic Usage
+## Subcommands
 
-```bash
-longbridge finance-calendar financial --symbol TSLA.US
-```
-
-```
-2026.01.28 (ET)  [Financials]  US  Tesla (TSLA.US)
-  Q4 FY2025 Earnings Release
-  EPS: Est 0.3466 / Act 0.24  |  Revenue: Est $24.8B / Act $24.9B
-```
+| Subcommand  | Description                                 |
+| ----------- | ------------------------------------------- |
+| `report`    | Earnings reports (upcoming and recent)      |
+| `dividend`  | Dividend announcements                      |
+| `split`     | Stock splits and merges                     |
+| `ipo`       | IPO listings                                |
+| `macrodata` | Macroeconomic data releases                 |
+| `closed`    | Market closure days                         |
 
 ## Examples
 
-### Upcoming earnings for a stock
+### Upcoming earnings reports
 
 ```bash
-longbridge finance-calendar financial --symbol TSLA.US
+longbridge finance-calendar report
 ```
 
-Shows Tesla's upcoming earnings dates along with analyst estimates for EPS and revenue. Use `--symbol` to narrow down to a specific stock.
+Shows upcoming earnings events from today. Displays EPS and revenue estimates alongside actual results for recently reported quarters.
 
-### Today's dividend events for the US market
+### Earnings for watchlist stocks
 
 ```bash
-longbridge finance-calendar dividend --market US
+longbridge finance-calendar report --filter watchlist --market US
 ```
 
-Lists all dividend-related events (ex-dividend dates, payment dates) scheduled for US-listed stocks. Useful for tracking which stocks are going ex-dividend.
+Scopes the earnings calendar to US stocks in your watchlist. Use `--filter positions` to limit to your current holdings instead.
+
+### Dividends for held positions
+
+```bash
+longbridge finance-calendar dividend --filter positions
+```
+
+Lists dividend events only for stocks you currently hold. Useful for tracking upcoming ex-dividend and payment dates.
+
+### Stock splits and merges in HK market
+
+```bash
+longbridge finance-calendar split --market HK
+```
+
+Shows both split and merge events for Hong Kong-listed stocks.
 
 ### High-importance macro events
 

--- a/docs/en/docs/cli/release-notes.md
+++ b/docs/en/docs/cli/release-notes.md
@@ -7,6 +7,14 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.19.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.19.2)
+
+- **`finance-calendar` revamp** — restructured into subcommands (`report`, `dividend`, `split`, `ipo`, `macrodata`, `closed`); new `--filter watchlist|positions` scopes events to your watchlist or holdings
+- **`quote`** — new "Last Chg%" column showing price change vs previous close
+- **`corp-action`** — defaults to 30 items; add `--all` to retrieve all records
+- **`update --force`** — skip version check and force reinstall; auto-retries with `sudo` on permission error
+- **TUI** — full mouse support; chart type toggle (line / candlestick) in stock detail view
+
 ### [v0.19.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.19.0)
 
 - **TUI: History orders tab** — press `Tab` on the Orders page to switch between Today and History; History mode fetches the last 30 days by default; press `f` to open a date-range filter popup

--- a/docs/zh-CN/docs/changelog.md
+++ b/docs/zh-CN/docs/changelog.md
@@ -6,6 +6,14 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-05-05
+
+### CLI v0.19.2
+
+- **`finance-calendar` 重构** — 改为子命令结构：`report`、`dividend`、`split`、`ipo`、`macrodata`、`closed`；新增 `--filter watchlist|positions` 按自选股或持仓筛选事件
+- **TUI 增强** — 支持鼠标操作；个股详情页新增折线图 / K 线图切换
+- **`quote`** — 新增「涨跌幅」列；`corp-action` 默认 30 条，`--all` 获取全部；`update --force` 跳过版本检查
+
 ## 2026-04-30
 
 ### CLI v0.19.0

--- a/docs/zh-CN/docs/cli/fundamentals/finance-calendar.md
+++ b/docs/zh-CN/docs/cli/fundamentals/finance-calendar.md
@@ -6,37 +6,52 @@ sidebar_position: 6
 
 # longbridge finance-calendar
 
-浏览即将到来的财经事件——财报发布、股息派发、IPO 及宏观经济数据发布，支持按标的、市场或事件类型过滤。
+浏览即将到来的财经事件——财报发布、股息派发、拆合股、IPO 及宏观经济数据，支持按标的、自选股、市场或事件类型过滤。
 
-## 基本用法
+## 子命令
 
-```bash
-longbridge finance-calendar financial --symbol TSLA.US
-```
-
-```
-2026.01.28 (ET)  [Financials]  US  Tesla (TSLA.US)
-  Q4 FY2025 Earnings Release
-  EPS: Est 0.3466 / Act 0.24  |  Revenue: Est $24.8B / Act $24.9B
-```
+| 子命令      | 说明                       |
+| ----------- | -------------------------- |
+| `report`    | 财报日历（即将和最新发布） |
+| `dividend`  | 股息公告                   |
+| `split`     | 拆股与合股                 |
+| `ipo`       | IPO 上市                   |
+| `macrodata` | 宏观经济数据发布           |
+| `closed`    | 市场休市日                 |
 
 ## 示例
 
-### 查看某股票的即将财报
+### 即将发布的财报
 
 ```bash
-longbridge finance-calendar financial --symbol TSLA.US
+longbridge finance-calendar report
 ```
 
-显示特斯拉即将到来的财报日期及分析师对 EPS 和营收的预测。使用 `--symbol` 缩小到特定股票。
+显示从今天起即将发布的财报事件，同时展示近期已发布季度的 EPS 和营收预估值与实际值。
 
-### 查看美股今日股息事件
+### 自选股中的美股财报
 
 ```bash
-longbridge finance-calendar dividend --market US
+longbridge finance-calendar report --filter watchlist --market US
 ```
 
-列出所有美股今日股息相关事件（除息日、派息日）。适用于追踪哪些股票即将除息。
+将财报日历限定为自选股中的美股。使用 `--filter positions` 则限定为当前持仓。
+
+### 持仓股票的分红事件
+
+```bash
+longbridge finance-calendar dividend --filter positions
+```
+
+只显示当前持仓股票的股息事件，适合追踪即将到来的除息日和派息日。
+
+### 港股拆合股事件
+
+```bash
+longbridge finance-calendar split --market HK
+```
+
+显示港股的拆股和合股事件。
 
 ### 高重要性宏观事件
 

--- a/docs/zh-CN/docs/cli/release-notes.md
+++ b/docs/zh-CN/docs/cli/release-notes.md
@@ -7,6 +7,14 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.19.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.19.2)
+
+- **`finance-calendar` 重构** — 改为子命令结构（`report`、`dividend`、`split`、`ipo`、`macrodata`、`closed`）；新增 `--filter watchlist|positions` 按自选股或持仓筛选事件
+- **`quote`** — 新增「涨跌幅」列，显示相较上一收盘价的变动幅度
+- **`corp-action`** — 默认返回 30 条，加 `--all` 获取全部记录
+- **`update --force`** — 跳过版本检查强制重装；权限不足时自动通过 `sudo` 重试
+- **TUI** — 支持鼠标操作；个股详情页新增折线图 / K 线图切换
+
 ### [v0.19.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.19.0)
 
 - **TUI：历史订单 Tab** — 在订单页面按 `Tab` 切换今日 / 历史两个视图；历史模式默认获取最近 30 天；按 `f` 打开日期范围筛选弹窗

--- a/docs/zh-HK/docs/changelog.md
+++ b/docs/zh-HK/docs/changelog.md
@@ -6,6 +6,14 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-05-05
+
+### CLI v0.19.2
+
+- **`finance-calendar` 重構** — 改為子命令結構：`report`、`dividend`、`split`、`ipo`、`macrodata`、`closed`；新增 `--filter watchlist|positions` 按自選股或持倉篩選事件
+- **TUI 增強** — 支援滑鼠操作；個股詳情頁新增折線圖 / K 線圖切換
+- **`quote`** — 新增「漲跌幅」欄；`corp-action` 預設 30 條，`--all` 取得全部；`update --force` 跳過版本檢查
+
 ## 2026-04-30
 
 ### CLI v0.19.0

--- a/docs/zh-HK/docs/cli/fundamentals/finance-calendar.md
+++ b/docs/zh-HK/docs/cli/fundamentals/finance-calendar.md
@@ -6,37 +6,52 @@ sidebar_position: 6
 
 # longbridge finance-calendar
 
-瀏覽即將到來的財經事件——財報發布、股息派發、IPO 及宏觀經濟數據發布，支持按標的、市場或事件類型篩選。
+瀏覽即將到來的財經事件——財報發布、股息派發、拆合股、IPO 及宏觀經濟數據，支援按標的、自選股、市場或事件類型篩選。
 
-## 基本用法
+## 子命令
 
-```bash
-longbridge finance-calendar financial --symbol TSLA.US
-```
-
-```
-2026.01.28 (ET)  [Financials]  US  Tesla (TSLA.US)
-  Q4 FY2025 Earnings Release
-  EPS: Est 0.3466 / Act 0.24  |  Revenue: Est $24.8B / Act $24.9B
-```
+| 子命令      | 說明                         |
+| ----------- | ---------------------------- |
+| `report`    | 財報日曆（即將和最新發布）   |
+| `dividend`  | 股息公告                     |
+| `split`     | 拆股與合股                   |
+| `ipo`       | IPO 上市                     |
+| `macrodata` | 宏觀經濟數據發布             |
+| `closed`    | 市場休市日                   |
 
 ## 示例
 
-### 查看某股票的即將財報
+### 即將發布的財報
 
 ```bash
-longbridge finance-calendar financial --symbol TSLA.US
+longbridge finance-calendar report
 ```
 
-顯示特斯拉即將到來的財報日期及分析師對 EPS 和營收的預測。使用 `--symbol` 縮小到特定股票。
+顯示從今天起即將發布的財報事件，同時展示近期已發布季度的 EPS 和營收預估值與實際值。
 
-### 查看美股今日股息事件
+### 自選股中的美股財報
 
 ```bash
-longbridge finance-calendar dividend --market US
+longbridge finance-calendar report --filter watchlist --market US
 ```
 
-列出所有美股今日股息相關事件（除息日、派息日）。適用於追蹤哪些股票即將除息。
+將財報日曆限定為自選股中的美股。使用 `--filter positions` 則限定為當前持倉。
+
+### 持倉股票的派息事件
+
+```bash
+longbridge finance-calendar dividend --filter positions
+```
+
+只顯示當前持倉股票的股息事件，適合追蹤即將到來的除息日和派息日。
+
+### 港股拆合股事件
+
+```bash
+longbridge finance-calendar split --market HK
+```
+
+顯示港股的拆股和合股事件。
 
 ### 高重要性宏觀事件
 

--- a/docs/zh-HK/docs/cli/release-notes.md
+++ b/docs/zh-HK/docs/cli/release-notes.md
@@ -7,6 +7,14 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.19.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.19.2)
+
+- **`finance-calendar` 重構** — 改為子命令結構（`report`、`dividend`、`split`、`ipo`、`macrodata`、`closed`）；新增 `--filter watchlist|positions` 按自選股或持倉篩選事件
+- **`quote`** — 新增「漲跌幅」欄，顯示相較上一收盤價的變動幅度
+- **`corp-action`** — 預設返回 30 條，加 `--all` 取得全部記錄
+- **`update --force`** — 跳過版本檢查強制重裝；權限不足時自動透過 `sudo` 重試
+- **TUI** — 支援滑鼠操作；個股詳情頁新增折線圖 / K 線圖切換
+
 ### [v0.19.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.19.0)
 
 - **TUI：歷史訂單 Tab** — 在訂單頁面按 `Tab` 切換今日 / 歷史兩個檢視；歷史模式預設獲取最近 30 天；按 `f` 開啟日期範圍篩選彈窗


### PR DESCRIPTION
## Summary

- Add CLI v0.19.2 release notes to `cli.md` and `changelog.md` (EN / zh-CN / zh-HK)
- Update `finance-calendar` command examples to reflect new subcommand structure (`report`, `dividend`, `split`, `ipo`, `macrodata`, `closed`) and `--filter watchlist|positions` option

## Changes

- `finance-calendar` revamp: restructured from single `<event_type>` argument into subcommands; new `--filter` option scopes events to watchlist or holdings
- `quote`: new "Last Chg%" column
- `corp-action`: defaults to 30 items, `--all` for full list
- `update --force`: skip version check; auto-retries with `sudo` on permission error
- TUI: full mouse support; chart type toggle (line / candlestick) in stock detail view

## Test plan

- [ ] Verify examples in `finance-calendar` section match `longbridge finance-calendar --help` output
- [ ] Check all three language versions are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)