### PR TITLE
fix(pricing): fix UnoCSS build errors and update page titles

### DIFF
--- a/docs/.vitepress/theme/components/Pricing.vue
+++ b/docs/.vitepress/theme/components/Pricing.vue
@@ -294,7 +294,7 @@ const t = computed(() => {
         </div>
         <div class="flex items-baseline gap-[5px] flex-wrap mb-1">
           <span
-            class="text-[1.9rem] font-bold leading-none tracking-[-0.02em] [font-feature-settings:'tnum']"
+            class="text-[1.9rem] font-bold leading-none tracking-[-0.02em]" style="font-feature-settings:'tnum'"
             :style="{ color: LEVEL_COLORS.lv1.hex }"
             >HK${{ priceOf('us_lv1') }}</span
           >
@@ -365,7 +365,7 @@ const t = computed(() => {
         <div class="text-[0.68rem] text-[var(--vp-c-text-3)] mb-0.5">{{ t.hkLv2GlobalLabel }}</div>
         <div class="flex items-baseline gap-[5px] flex-wrap mb-1">
           <span
-            class="text-[1.9rem] font-bold leading-none tracking-[-0.02em] [font-feature-settings:'tnum']"
+            class="text-[1.9rem] font-bold leading-none tracking-[-0.02em]" style="font-feature-settings:'tnum'"
             :style="{ color: LEVEL_COLORS.lv2.hex }"
             >HK${{ priceOf('hk_lv2_global') }}</span
           >
@@ -445,7 +445,7 @@ const t = computed(() => {
         </div>
         <div class="flex items-baseline gap-[5px] flex-wrap mb-1">
           <span
-            class="text-[1.9rem] font-bold leading-none tracking-[-0.02em] [font-feature-settings:'tnum']"
+            class="text-[1.9rem] font-bold leading-none tracking-[-0.02em]" style="font-feature-settings:'tnum'"
             :style="{ color: LEVEL_COLORS.opra.hex }"
             >HK${{ priceOf('opra') }}</span
           >

--- a/docs/en/pricing.md
+++ b/docs/en/pricing.md
@@ -1,5 +1,5 @@
 ---
-title: 'Market Data Pricing'
+title: 'Pricing'
 id: pricing
 layout: page
 sidebar: false

--- a/docs/postcss.config.mjs
+++ b/docs/postcss.config.mjs
@@ -10,6 +10,7 @@ function gatedTailwind() {
   return {
     postcssPlugin: 'gated-tailwindcss',
     prepare(result) {
+      if (!result.root) return {}
       const css = result.root.toString()
       // Only run Tailwind if the file imports tailwindcss
       if (!css.includes('@import "tailwindcss"') && !css.includes("@import 'tailwindcss'")) {

--- a/docs/zh-CN/pricing.md
+++ b/docs/zh-CN/pricing.md
@@ -1,5 +1,5 @@
 ---
-title: '行情权限定价'
+title: '定价'
 id: pricing
 layout: page
 sidebar: false

--- a/docs/zh-HK/pricing.md
+++ b/docs/zh-HK/pricing.md
@@ -1,5 +1,5 @@
 ---
-title: '行情權限定價'
+title: '定價'
 id: pricing
 layout: page
 sidebar: false


### PR DESCRIPTION
## Summary

- Fix UnoCSS build error: `[font-feature-settings:'tnum']` arbitrary class causes "Unknown word tnum&" — moved to static `style` attribute
- Fix PostCSS crash: add `result.root` null guard in `postcss.config.mjs`
- Simplify pricing page frontmatter titles to "Pricing / 定价 / 定價"

## Test plan

- [ ] Verify `bun run build:release` completes without errors
- [ ] Verify pricing page renders correctly in all three locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)