### PR TITLE
style(home): homepage visual polish pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,10 @@ longbridge quote AAPL.US NVDA.US
 
 `docs/.vitepress/utils.ts` 的 `rewriteMarkdownPath` 处理 URL 生成。`slug` frontmatter 覆盖默认路径：绝对 slug（`/foo`）替换整个路径；相对 slug 相对文件目录解析。
 
+## 独立页面路径结构
+
+新增独立页面（如 pricing、about 等顶级页面）必须使用文件夹结构：`docs/pricing/index.md`，而不是 `docs/pricing.md`。Nginx 解析 `/pricing` 时查找的是 `pricing/index.html`，用 `pricing.md` 生成的是 `pricing.html`，会导致 404。
+
 ## 静态资源
 
 所有图片/静态文件必须上传 CDN 后引用 URL，不得放入仓库。

--- a/docs/.vitepress/theme/components/NewHomePage/ArchCanvas.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/ArchCanvas.vue
@@ -167,7 +167,7 @@ const { t } = useI18n()
   letter-spacing: 0.06em;
 }
 .ab-label-brand {
-  color: var(--brand-color);
+  color: var(--vp-c-text-1);
 }
 
 .ab-group-box {
@@ -181,8 +181,8 @@ const { t } = useI18n()
   flex: 1;
 }
 .ab-box-brand {
-  border-color: color-mix(in srgb, var(--brand-color) 30%, var(--vp-c-divider));
-  background: color-mix(in srgb, var(--brand-color) 2%, var(--vp-c-bg));
+  border-color: var(--vp-c-divider);
+  background: var(--vp-c-bg);
   justify-content: center;
   align-items: center;
 }
@@ -229,7 +229,7 @@ const { t } = useI18n()
   transition: background 0.15s;
 }
 .ab-tool:hover {
-  background: color-mix(in srgb, var(--brand-color) 8%, transparent);
+  background: var(--vp-c-bg-elv);
 }
 
 .ab-tool-name {
@@ -244,9 +244,9 @@ const { t } = useI18n()
 }
 .ab-tool-code {
   font-size: 0.55rem;
-  color: var(--brand-color);
+  color: var(--vp-c-text-3);
   font-family: var(--vp-font-family-mono);
-  background: color-mix(in srgb, var(--brand-color) 5%, transparent);
+  background: var(--vp-c-bg-soft);
   padding: 0.1rem 0.25rem;
   border-radius: 0.125rem;
   width: fit-content;
@@ -262,7 +262,7 @@ const { t } = useI18n()
 .ab-gw-title {
   font-size: 0.85rem;
   font-weight: 700;
-  color: var(--brand-color);
+  color: var(--vp-c-text-1);
   white-space: nowrap;
 }
 
@@ -284,7 +284,7 @@ const { t } = useI18n()
   min-width: 9rem;
 }
 .ab-svc:hover {
-  background: color-mix(in srgb, var(--brand-color) 8%, transparent);
+  background: var(--vp-c-bg-elv);
 }
 .ab-svc-name {
   font-size: 0.78rem;
@@ -294,7 +294,7 @@ const { t } = useI18n()
 .ab-svc-count {
   font-size: 0.65rem;
   font-weight: 700;
-  color: var(--brand-color);
+  color: var(--vp-c-text-3);
   font-family: var(--vp-font-family-mono);
 }
 
@@ -347,8 +347,8 @@ const { t } = useI18n()
   height: 1.5px;
   background: repeating-linear-gradient(
     90deg,
-    var(--brand-color) 0px,
-    var(--brand-color) 5px,
+    var(--vp-c-text-3) 0px,
+    var(--vp-c-text-3) 5px,
     transparent 5px,
     transparent 8px
   );
@@ -362,7 +362,7 @@ const { t } = useI18n()
 .ab-arrow-head {
   width: 0;
   height: 0;
-  border-left: 6px solid var(--brand-color);
+  border-left: 6px solid var(--vp-c-text-3);
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
   flex-shrink: 0;
@@ -396,8 +396,8 @@ const { t } = useI18n()
     flex: 1;
     background: repeating-linear-gradient(
       180deg,
-      var(--brand-color) 0px,
-      var(--brand-color) 5px,
+      var(--vp-c-text-3) 0px,
+      var(--vp-c-text-3) 5px,
       transparent 5px,
       transparent 8px
     );
@@ -406,7 +406,7 @@ const { t } = useI18n()
   .ab-arrow-head {
     border-left: 4px solid transparent;
     border-right: 4px solid transparent;
-    border-top: 6px solid var(--brand-color);
+    border-top: 6px solid var(--vp-c-text-3);
     border-bottom: none;
   }
   .ab-arrow-dir {

--- a/docs/.vitepress/theme/components/NewHomePage/CapSection.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/CapSection.vue
@@ -84,7 +84,7 @@ const caps = [
 <style scoped>
 .cap-section {
   padding: 4rem 0;
-  background: var(--vp-c-bg-soft);
+  background: var(--vp-c-bg);
 }
 .cap-content {
   max-width: 64rem;

--- a/docs/.vitepress/theme/components/NewHomePage/CoreFeaturesSection.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/CoreFeaturesSection.vue
@@ -30,6 +30,15 @@ const links: Record<string, string> = {
   llm: '/docs/llm',
 }
 
+const accents: Record<string, string> = {
+  skill: '#00dbb6',
+  cli: '#fc5200',
+  mcp: '#6366f1',
+  sdk: '#00b8b8',
+  paper: '#f59e0b',
+  llm: '#a855f7',
+}
+
 const products = ['skill', 'cli', 'mcp', 'sdk', 'paper', 'llm']
 </script>
 
@@ -41,15 +50,30 @@ const products = ['skill', 'cli', 'mcp', 'sdk', 'paper', 'llm']
     </div>
 
     <div class="core-grid">
-      <a v-for="key in products" :key="key" :href="links[key]" class="core-card">
+      <a
+        v-for="key in products"
+        :key="key"
+        :href="links[key]"
+        class="core-card"
+        :style="{
+          '--card-accent': accents[key],
+          background: `radial-gradient(280px 140px at 100% 0%, color-mix(in srgb, ${accents[key]} 9%, transparent), transparent 70%), var(--vp-c-bg)`,
+        }">
         <div class="core-card-inner">
           <div class="core-card-top">
-            <span class="core-icon" v-html="icons[key as keyof typeof icons]" />
+            <span class="core-icon" :style="{ color: accents[key] }" v-html="icons[key as keyof typeof icons]" />
             <span class="core-card-title">{{ $t(`core.${key}.title`) }}</span>
           </div>
           <p class="core-card-desc">{{ $t(`core.${key}.desc`) }}</p>
           <div class="core-tags">
-            <span v-for="tag in tags[key]" :key="tag" class="core-tag">{{ tag }}</span>
+            <span
+              v-for="tag in tags[key]"
+              :key="tag"
+              class="core-tag"
+              :style="{
+                background: `color-mix(in srgb, ${accents[key]} 10%, transparent)`,
+                color: accents[key],
+              }">{{ tag }}</span>
           </div>
         </div>
       </a>
@@ -82,7 +106,6 @@ const products = ['skill', 'cli', 'mcp', 'sdk', 'paper', 'llm']
   display: flex;
   width: 1.5rem;
   height: 1.5rem;
-  color: var(--brand-color);
   flex-shrink: 0;
 }
 .core-icon :deep(svg) {
@@ -101,8 +124,6 @@ const products = ['skill', 'cli', 'mcp', 'sdk', 'paper', 'llm']
   font-size: 0.62rem;
   font-weight: 600;
   font-family: var(--vp-font-family-mono);
-  background: color-mix(in srgb, var(--brand-color) 10%, transparent);
-  color: var(--brand-color);
 }
 
 /* Grid */
@@ -129,18 +150,18 @@ const products = ['skill', 'cli', 'mcp', 'sdk', 'paper', 'llm']
   position: relative;
   border-radius: 1rem;
   border: 1px solid var(--vp-c-divider);
-  background: var(--vp-c-bg);
   text-decoration: none !important;
   overflow: hidden;
-  transition: border-color 0.2s, transform 0.2s;
+  isolation: isolate;
+  transition: transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 220ms cubic-bezier(0.2, 0.8, 0.2, 1), border-color 220ms;
 }
 :root.dark .core-card {
-  background: var(--vp-c-bg-soft);
   border-color: color-mix(in srgb, var(--vp-c-divider) 80%, transparent);
 }
 .core-card:hover {
-  border-color: var(--brand-color);
-  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--card-accent, var(--brand-color)) 50%, var(--vp-c-divider));
+  transform: translateY(-3px);
+  box-shadow: 0 16px 36px -10px rgba(10, 14, 25, 0.13), 0 3px 12px -5px rgba(10, 14, 25, 0.06);
 }
 
 .core-card-inner {

--- a/docs/.vitepress/theme/components/NewHomePage/CoreFeaturesSection.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/CoreFeaturesSection.vue
@@ -33,8 +33,8 @@ const links: Record<string, string> = {
 const accents: Record<string, string> = {
   skill: '#00dbb6',
   cli: '#fc5200',
-  mcp: '#6366f1',
-  sdk: '#00b8b8',
+  mcp: '#3b82f6',
+  sdk: '#22c55e',
   paper: '#f59e0b',
   llm: '#a855f7',
 }

--- a/docs/.vitepress/theme/components/NewHomePage/GetStarted.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/GetStarted.vue
@@ -62,18 +62,15 @@ const entries = [
   position: relative;
   padding: 4rem 0;
   overflow: hidden;
+  border-top: 1px solid var(--vp-c-divider);
+  border-bottom: 1px solid var(--vp-c-divider);
 }
 
 /* Gradient background */
 .gs-bg {
   position: absolute;
   inset: 0;
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--brand-color) 8%, var(--vp-c-bg-soft)) 0%,
-    var(--vp-c-bg-soft) 40%,
-    color-mix(in srgb, var(--cyan-60, #66d5c2) 6%, var(--vp-c-bg-soft)) 100%
-  );
+  background: var(--vp-c-bg-soft);
   z-index: 0;
 }
 

--- a/docs/.vitepress/theme/components/NewHomePage/HeroSection.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/HeroSection.vue
@@ -3,7 +3,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import FlickeringGrid from '../inspira/FlickeringGrid.vue'
 import ColourfulText from '../inspira/ColourfulText.vue'
-import InteractiveHoverButton from '../inspira/InteractiveHoverButton.vue'
+import ShimmerButton from '../inspira/ShimmerButton.vue'
 
 const { t } = useI18n()
 
@@ -108,18 +108,21 @@ const ctaReadDocs = computed(() => t('hero.cta.readDocs'))
       <!-- CTA Buttons -->
       <div class="hero-cta">
         <a href="https://open.longbridge.com/account" class="hero-link">
-          <InteractiveHoverButton
-            :text="ctaGetStarted"
-            dot-color="var(--brand-10)"
-            hover-text-color="var(--brand-100)"
-            class="hero-btn-primary" />
+          <ShimmerButton
+            :shimmer-color="'rgba(255,255,255,0.6)'"
+            shimmer-size="0.04em"
+            shimmer-duration="2.5s"
+            border-radius="100px"
+            :background="'var(--brand-100)'"
+            class="hero-btn-primary">
+            {{ ctaGetStarted }}
+          </ShimmerButton>
         </a>
-        <a href="/docs/" class="hero-link">
-          <InteractiveHoverButton
-            :text="ctaReadDocs"
-            dot-color="var(--brand-100)"
-            hover-text-color="var(--brand-10)"
-            class="hero-btn-secondary" />
+        <a href="/docs/" class="hero-cta-secondary">
+          {{ ctaReadDocs }}
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M5 12h14"/><path d="m12 5 7 7-7 7"/>
+          </svg>
         </a>
       </div>
     </div>
@@ -280,21 +283,46 @@ const ctaReadDocs = computed(() => t('hero.cta.readDocs'))
   text-decoration: none !important;
 }
 
-.hero-btn-primary,
-.hero-btn-secondary {
-  padding: 0.625rem 2rem;
-  font-size: 1rem;
-}
-
 .hero-btn-primary {
-  border: 1.5px solid var(--brand-100);
-  background: var(--brand-100);
-  color: var(--brand-10);
+  padding: 0.7rem 2.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #fff !important;
+  letter-spacing: 0.01em;
 }
 
-.hero-btn-secondary {
-  background: var(--brand-10);
-  border: 1.5px solid var(--brand-100);
+:root.dark .hero-btn-primary {
+  color: #fff !important;
+}
+
+.hero-cta-secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.7rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 600;
   color: var(--brand-100);
+  text-decoration: none !important;
+  border-radius: 100px;
+  border: 1.5px solid color-mix(in srgb, var(--brand-100) 40%, transparent);
+  transition: gap 0.2s, border-color 0.2s, background 0.2s;
+  background: transparent;
+}
+
+.hero-cta-secondary:hover {
+  gap: 0.625rem;
+  border-color: var(--brand-100);
+  background: color-mix(in srgb, var(--brand-100) 6%, transparent);
+}
+
+:root.dark .hero-cta-secondary {
+  color: var(--brand-80, var(--brand-100));
+  border-color: color-mix(in srgb, var(--brand-80, var(--brand-100)) 35%, transparent);
+}
+
+:root.dark .hero-cta-secondary:hover {
+  border-color: var(--brand-80, var(--brand-100));
+  background: color-mix(in srgb, var(--brand-80, var(--brand-100)) 8%, transparent);
 }
 </style>

--- a/docs/.vitepress/theme/components/NewHomePage/MarketCoverage.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/MarketCoverage.vue
@@ -74,7 +74,7 @@ const markets = [
 </template>
 
 <style scoped>
-.mc-section { padding: 3rem 0 4rem; background: var(--vp-c-bg-soft); }
+.mc-section { padding: 3rem 0 4rem; background: var(--vp-c-bg-soft); border-top: 1px solid var(--vp-c-divider); border-bottom: 1px solid var(--vp-c-divider); }
 
 .mc-grid {
   display: grid;

--- a/docs/.vitepress/theme/components/NewHomePage/PlatformStats.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/PlatformStats.vue
@@ -5,9 +5,8 @@ import NumberTicker from '../inspira/NumberTicker.vue'
 
 const { t } = useI18n()
 
-// Logo-inspired stat colors: teal, yellow/gold, orange, cyan
+// Logo-inspired stat colors: teal, yellow/gold, orange, dark
 let statColors = ['#00b8b8', '#d4a800', '#c34607', '#505050']
-// if dark
 if (document.querySelector('html')?.classList.contains('dark')) {
   statColors = ['#00dbb6', '#ffe000', '#fc5200', '#AAAAAA']
 }

--- a/docs/.vitepress/theme/components/NewHomePage/ProductCLI.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/ProductCLI.vue
@@ -316,6 +316,8 @@ function copyInstall() {
 .cli-section {
   padding: 4rem 0;
   background: var(--vp-c-bg-soft);
+  border-top: 1px solid var(--vp-c-divider);
+  border-bottom: 1px solid var(--vp-c-divider);
 }
 
 .cli-container {
@@ -374,11 +376,11 @@ function copyInstall() {
 }
 .cli-feat.active {
   background: var(--vp-c-bg);
-  border-color: var(--brand-color);
+  border-color: var(--vp-c-text-2);
   color: var(--vp-c-text-1);
 }
 .cli-feat.active .cli-feat-icon {
-  color: var(--brand-color);
+  color: var(--vp-c-text-2);
 }
 
 .cli-feat-icon {

--- a/docs/.vitepress/theme/components/NewHomePage/ProductMCP.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/ProductMCP.vue
@@ -346,6 +346,8 @@ function copyCmd() {
 .mcp-section {
   padding: 4rem 1rem;
   background: var(--vp-c-bg-soft);
+  border-top: 1px solid var(--vp-c-divider);
+  border-bottom: 1px solid var(--vp-c-divider);
   overflow: hidden;
 }
 

--- a/docs/.vitepress/theme/components/NewHomePage/ProductOpenAPI.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/ProductOpenAPI.vue
@@ -494,7 +494,7 @@ function copyInstall() {
 .sdk-cell {
   border-radius: 0.75rem;
   border: 1px solid var(--vp-c-divider);
-  background: radial-gradient(200px 120px at 100% 0%, color-mix(in srgb, var(--brand-color) 8%, transparent), transparent 70%), var(--vp-c-bg-soft);
+  background: radial-gradient(200px 120px at 100% 0%, color-mix(in srgb, var(--brand-color) 13%, transparent), transparent 70%), var(--vp-c-bg-soft);
   padding: 1rem;
   transition: border-color 0.2s, transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }

--- a/docs/.vitepress/theme/components/NewHomePage/ProductOpenAPI.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/ProductOpenAPI.vue
@@ -494,12 +494,14 @@ function copyInstall() {
 .sdk-cell {
   border-radius: 0.75rem;
   border: 1px solid var(--vp-c-divider);
-  background: var(--vp-c-bg-soft);
+  background: radial-gradient(200px 120px at 100% 0%, color-mix(in srgb, var(--brand-color) 8%, transparent), transparent 70%), var(--vp-c-bg-soft);
   padding: 1rem;
-  transition: all 0.25s;
+  transition: border-color 0.2s, transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
-.sdk-cell:hover {
-  border-color: color-mix(in srgb, var(--brand-color) 30%, var(--vp-c-divider));
+.sdk-cell:not(.sdk-cell-hero):hover {
+  border-color: color-mix(in srgb, var(--brand-color) 40%, var(--vp-c-divider));
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px -6px rgba(10, 14, 25, 0.10);
 }
 
 /* Hero code cell */
@@ -511,6 +513,11 @@ function copyInstall() {
   padding: 0;
   display: flex;
   flex-direction: column;
+  background: var(--vp-c-bg) !important;
+}
+
+:root.dark .sdk-cell-hero {
+  background: var(--vp-c-bg-elv, var(--vp-c-bg)) !important;
 }
 
 .sdk-hero-tabs {
@@ -543,7 +550,7 @@ function copyInstall() {
   background: transparent; border: none; cursor: pointer; transition: all 0.2s;
 }
 .sdk-cap-tab:hover { color: var(--vp-c-text-2); }
-.sdk-cap-tab.active { color: var(--vp-c-text-1); background: var(--vp-c-bg); }
+.sdk-cap-tab.active { color: var(--vp-c-text-1); background: var(--vp-c-bg-soft); }
 
 .sdk-code-wrap { position: relative; flex: 1; overflow: auto; padding: 0.75rem; }
 .sdk-code :deep(pre) { margin: 0; font-size: 0.72rem; line-height: 1.6; font-family: var(--vp-font-family-mono); background: transparent !important; }

--- a/docs/.vitepress/theme/components/NewHomePage/ProductSkill.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/ProductSkill.vue
@@ -344,7 +344,14 @@ function copyCli() {
 <style scoped>
 .skill-section {
   padding: 4rem 0;
-  background: var(--vp-c-bg);
+  background:
+    radial-gradient(ellipse 80% 50% at 50% 0%, color-mix(in srgb, #00dbb6 7%, transparent), transparent 70%),
+    var(--vp-c-bg);
+}
+:root.dark .skill-section {
+  background:
+    radial-gradient(ellipse 80% 50% at 50% 0%, color-mix(in srgb, #00dbb6 12%, transparent), transparent 70%),
+    var(--vp-c-bg);
 }
 
 /* Header */
@@ -396,7 +403,7 @@ function copyCli() {
   padding: 0.75rem 1rem;
   border-radius: 0.625rem;
   border: 1px solid var(--vp-c-divider);
-  background: var(--vp-c-bg-soft);
+  background: color-mix(in srgb, var(--vp-c-bg-soft) 60%, transparent);
 }
 
 .skill-install-ai-text {
@@ -441,7 +448,7 @@ function copyCli() {
   border: 1px solid var(--vp-c-divider);
   border-radius: 0.5rem;
   overflow: hidden;
-  background: var(--vp-c-bg-soft);
+  background: color-mix(in srgb, var(--vp-c-bg-soft) 60%, transparent);
 }
 
 .skill-install-tabs {
@@ -564,7 +571,7 @@ function copyCli() {
   border-radius: 0.75rem;
   border: 1px solid var(--vp-c-divider);
   overflow: hidden;
-  background: var(--vp-c-bg-soft);
+  background: color-mix(in srgb, var(--vp-c-bg-soft) 55%, transparent);
 }
 .skill-mock-bar {
   display: flex;
@@ -710,9 +717,9 @@ function copyCli() {
   font-size: 0.875rem;
   font-family: var(--vp-font-family-mono);
   color: var(--vp-c-text-2);
-  padding: 0.25rem 0.625rem;
+  padding: 0.15rem 0.5rem;
   border-radius: 0.25rem;
-  background: var(--vp-c-bg);
+  background: color-mix(in srgb, var(--vp-c-divider) 30%, transparent);
   border: 1px solid var(--vp-c-divider);
 }
 .skill-mock-streaming {


### PR DESCRIPTION
## Summary

- **ArchCanvas**: replace all `--brand-color` usages with neutral vars (`--vp-c-text-1/3`, `--vp-c-divider`, `--vp-c-bg-elv`) on arrows, labels, API Gateway box, hover states
- **ProductCLI**: active feature item border/icon uses `--vp-c-text-2` (dark, not brand); section gets `border-top` + `border-bottom`
- **Gray section borders**: ProductMCP, GetStarted, MarketCoverage all get `border-top` + `border-bottom` to delineate from adjacent white sections
- **CapSection**: switched from `bg-soft` to `bg` (white) to break consecutive gray run with MCP section above it
- **CoreFeaturesSection**: 6 card accents now cover distinct hues across the color wheel — teal, orange, blue, green, amber, purple (was duplicating teal and blue-purple)
- **ProductSkill**: top-center radial gradient (`#00dbb6` 7%/12% light/dark); code stream blocks get lighter background with solid border
- **ProductOpenAPI**: side-cell brand gradient raised from 8% → 13% for better visibility
- **GetStarted**: removed messy 135deg multi-color gradient, replaced with flat `bg-soft`

## Test plan

- [ ] Light mode: verify section alternation (white/gray/white) is visually clear throughout the page
- [ ] Dark mode: verify Skill section teal gradient is visible; section borders are subtle but present
- [ ] Developer Tools cards: confirm all 6 cards read as distinct colors
- [ ] Platform Architecture diagram: arrows and labels should appear neutral/monochrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)