### PR TITLE
docs(cli): v0.20.0 new commands documentation

### DIFF
--- a/docs/en/docs/cli/account/bank-cards.md
+++ b/docs/en/docs/cli/account/bank-cards.md
@@ -1,0 +1,37 @@
+---
+title: 'bank-cards'
+sidebar_label: 'bank-cards'
+sidebar_position: 20
+---
+
+# longbridge bank-cards
+
+List the bank cards linked to your Longbridge account.
+
+## Basic Usage
+
+```bash
+longbridge bank-cards
+```
+
+```
+| bank                         | account          | currency | swift    | region         | status |
+|------------------------------|------------------|----------|----------|----------------|--------|
+| DBS Bank                     | 2712065366       | SGD      | DBSSSGSG | Singapore      | active |
+| China Merchants Bank         | 6212998605139779 | ALL      | CMBCHKHH | Hong Kong      | active |
+```
+
+## Examples
+
+### List linked bank cards
+
+```bash
+longbridge bank-cards
+longbridge bank-cards --format json
+```
+
+Shows all linked bank cards with bank name, masked account number, currency, SWIFT code, and status.
+
+## Requirements
+
+OAuth account permission required. See the [account permission setup](/docs/trade/) guide.

--- a/docs/en/docs/cli/account/deposits.md
+++ b/docs/en/docs/cli/account/deposits.md
@@ -1,0 +1,56 @@
+---
+title: 'deposits'
+sidebar_label: 'deposits'
+sidebar_position: 22
+---
+
+# longbridge deposits
+
+View your deposit history with optional filtering by state and currency.
+
+## Basic Usage
+
+```bash
+longbridge deposits
+```
+
+```
+Total: 3
+
+| id      | date                 | amount   | currency | type | state    |
+|---------|----------------------|----------|----------|------|----------|
+| 2096375 | 2026-04-30T07:57:49Z | 3000.00  | USD      | Wire | Credited |
+| 2036889 | 2026-03-27T02:54:49Z | 10000.00 | USD      | Wire | Credited |
+| 1980183 | 2026-03-02T02:32:11Z | 3132.60  | USD      | Wire | Credited |
+```
+
+## Examples
+
+### View all deposits
+
+```bash
+longbridge deposits
+```
+
+### Filter by state
+
+```bash
+# 0=pending, 1=credited, 2=failed
+longbridge deposits --states 1
+```
+
+### Filter by currency
+
+```bash
+longbridge deposits --currencies HKD,USD
+```
+
+### Paginate
+
+```bash
+longbridge deposits --page 2 --count 50
+```
+
+## Requirements
+
+OAuth account permission required. See the [account permission setup](/docs/trade/) guide.

--- a/docs/en/docs/cli/account/portfolio.md
+++ b/docs/en/docs/cli/account/portfolio.md
@@ -45,6 +45,14 @@ longbridge portfolio --format json
 
 Displays total asset value, total and today's P/L, and a breakdown of market value per market.
 
+### Short margin deposit
+
+```bash
+longbridge portfolio short-margin
+```
+
+Shows the short-selling margin deposit details for your account, including per-position margin requirements and deposit amounts.
+
 ## Requirements
 
 OAuth account permission required. See the [account permission setup](/docs/trade/) guide.

--- a/docs/en/docs/cli/account/withdrawals.md
+++ b/docs/en/docs/cli/account/withdrawals.md
@@ -1,0 +1,42 @@
+---
+title: 'withdrawals'
+sidebar_label: 'withdrawals'
+sidebar_position: 21
+---
+
+# longbridge withdrawals
+
+View your withdrawal history.
+
+## Basic Usage
+
+```bash
+longbridge withdrawals
+```
+
+```
+Total: 5
+
+| id      | date                 | amount   | currency | type | state    |
+|---------|----------------------|----------|----------|------|----------|
+| 2096375 | 2026-04-30T07:57:49Z | 3000.00  | USD      | Wire | Credited |
+| 2036889 | 2026-03-27T02:54:49Z | 10000.00 | USD      | Wire | Credited |
+```
+
+## Examples
+
+### View withdrawal history
+
+```bash
+longbridge withdrawals
+```
+
+### Paginate through records
+
+```bash
+longbridge withdrawals --page 2 --count 50
+```
+
+## Requirements
+
+OAuth account permission required. See the [account permission setup](/docs/trade/) guide.

--- a/docs/en/docs/cli/content/news.md
+++ b/docs/en/docs/cli/content/news.md
@@ -45,3 +45,20 @@ longbridge news detail 282276051
 ```
 
 Fetches the full Markdown content of a single article by its ID. Article IDs are available in the `id` field of the list output.
+
+### Search news by keyword
+
+```bash
+longbridge news search "AI stocks"
+longbridge news search TSLA --count 10
+```
+
+```
+| id        | title                                                  | time                 |
+|-----------|--------------------------------------------------------|----------------------|
+| 285710139 | Why stocks hit new highs amid ceasefire bets           | 2026-05-08T10:53:18Z |
+| 285708897 | Why Akamai stock jumped 26%                            | 2026-05-08T09:54:55Z |
+...
+```
+
+Searches news articles by keyword across all markets. Use `--count` to control the number of results (default: 20).

--- a/docs/en/docs/cli/content/topic.md
+++ b/docs/en/docs/cli/content/topic.md
@@ -35,6 +35,15 @@ longbridge topic NVDA.US
 
 Lists community posts and discussions related to the symbol, including titles, descriptions, and engagement metrics.
 
+### Search topics by keyword
+
+```bash
+longbridge topic search TSLA
+longbridge topic search "AI stocks" --count 10
+```
+
+Searches community topics by keyword. Returns posts matching the keyword with title, author excerpt, and engagement stats. Use `--count` to control the number of results (default: 20).
+
 ### Read the full content of a post
 
 ```bash

--- a/docs/en/docs/cli/fundamentals/analyst-estimates.md
+++ b/docs/en/docs/cli/fundamentals/analyst-estimates.md
@@ -1,0 +1,48 @@
+---
+title: 'analyst-estimates'
+sidebar_label: 'analyst-estimates'
+sidebar_position: 12
+---
+
+# longbridge analyst-estimates
+
+View historical and forward EPS analyst consensus estimates for a stock, including high/low/mean/median and the number of covering analysts.
+
+## Basic Usage
+
+```bash
+longbridge analyst-estimates TSLA.US
+```
+
+```
+estimate:
+| currency | day        | high | low  | mean | median | num | value |
+|----------|------------|------|------|------|--------|-----|-------|
+| USD      | 2026-03-31 | 0.24 | 0.07 | 0.15 | 0.13   | 8   |       |
+| USD      | 2026-06-30 | 0.38 | 0.09 | 0.21 | 0.18   | 8   |       |
+| USD      | 2026-09-30 | 0.48 | 0.14 | 0.29 | 0.26   | 8   |       |
+| USD      | 2026-12-31 | 0.58 | 0.14 | 0.35 | 0.32   | 7   |       |
+...
+```
+
+When `value` is filled, the actual reported EPS is available. Empty means the period has not yet been reported.
+
+## Examples
+
+### EPS estimates
+
+```bash
+longbridge analyst-estimates TSLA.US
+longbridge analyst-estimates AAPL.US
+longbridge analyst-estimates NVDA.US
+```
+
+Returns the analyst EPS consensus across past and future periods, with dispersion (high/low) and coverage count.
+
+### JSON output
+
+```bash
+longbridge analyst-estimates TSLA.US --format json
+```
+
+Returns the full estimate series as JSON for programmatic use.

--- a/docs/en/docs/cli/fundamentals/financial-statement.md
+++ b/docs/en/docs/cli/fundamentals/financial-statement.md
@@ -1,0 +1,84 @@
+---
+title: 'financial-statement'
+sidebar_label: 'financial-statement'
+sidebar_position: 3
+---
+
+# longbridge financial-statement
+
+Fetch a fully detailed, line-item financial statement — income statement, balance sheet, or cash flow — for any public company.
+
+## Basic Usage
+
+```bash
+longbridge financial-statement TSLA.US --kind IS
+```
+
+```
+  (in USD)
+                                 Q1 2026     Q4 2025     Q3 2025     Q2 2025     Q1 2025      YoY
+─────────────────────────────────────────────────────────────────────────────────────────────────
+
+Revenue
+  Total Operating Revenue       22.39B      24.90B      28.09B      22.50B      19.34B   -10.1%
+    Revenue                     22.39B      24.90B      28.09B      22.50B      19.34B   -10.1%
+
+Cost
+  Operating Cost                17.67B      19.89B      23.04B      18.62B      16.18B   -11.2%
+    COGS                        17.67B      19.89B      23.04B      18.62B      16.18B   -11.2%
+  Gross Profit                   4.72B       5.01B       5.05B       3.88B       3.15B    -5.8%
+...
+```
+
+## Examples
+
+### Quarterly income statement
+
+```bash
+longbridge financial-statement TSLA.US --kind IS --report qf
+longbridge financial-statement AAPL.US --kind IS --report qf
+```
+
+Returns the quarterly income statement with a side-by-side YoY comparison.
+
+### Annual balance sheet
+
+```bash
+longbridge financial-statement TSLA.US --kind BS --report af
+longbridge financial-statement 700.HK --kind BS --report af
+```
+
+Returns the full annual balance sheet with assets, liabilities, and equity breakdowns.
+
+### Cash flow statement
+
+```bash
+longbridge financial-statement NVDA.US --kind CF
+```
+
+Returns operating, investing, and financing cash flows.
+
+### All three statements
+
+```bash
+longbridge financial-statement AAPL.US
+```
+
+Fetches all three statement types in one call. Equivalent to `--kind ALL`.
+
+### Cumulative period
+
+```bash
+longbridge financial-statement TSLA.US --kind IS --report cumul
+```
+
+Returns the cumulative year-to-date income statement.
+
+### Report period options
+
+| `--report` | Description |
+|---|---|
+| `af` | Annual (default) |
+| `saf` | Semi-annual |
+| `qf` | Quarterly |
+| `cumul` | Cumulative (year-to-date) |

--- a/docs/en/docs/cli/fundamentals/institution-rating.md
+++ b/docs/en/docs/cli/fundamentals/institution-rating.md
@@ -50,6 +50,40 @@ longbridge institution-rating detail TSLA.US
 
 The `detail` subcommand lists the historical rating distribution by week and individual analyst price targets, so you can track how sentiment has shifted over time.
 
+### Rating history with target price changes
+
+```bash
+longbridge institution-rating TSLA.US --history
+```
+
+Shows how the rating distribution and consensus price target have changed over time — useful for tracking momentum shifts in analyst sentiment.
+
+### Industry-wide ranking
+
+```bash
+longbridge institution-rating TSLA.US --industry-rank
+# Paginate
+longbridge institution-rating TSLA.US --industry-rank --page 2 --limit 20
+```
+
+```
+| key             | value      |
+|-----------------|------------|
+| industry_name   | Automobile Manufacturers |
+| industry_rank   | 1          |
+| industry_mean   | 10         |
+| industry_total  | 30         |
+
+items:
+| symbol   | name   | buy | hold | sell | total | rank |
+|----------|--------|-----|------|------|-------|------|
+| TSLA.US  | Tesla  | 23  | 17   | 10   | 51    | 1    |
+| GM.US    | GM     | 20  | 5    | 1    | 27    | 2    |
+...
+```
+
+Ranks every stock in the same industry by total analyst coverage, so you can see where your stock stands relative to peers.
+
 ### JSON for monitoring
 
 ```bash

--- a/docs/en/docs/cli/fundamentals/valuation-rank.md
+++ b/docs/en/docs/cli/fundamentals/valuation-rank.md
@@ -1,0 +1,55 @@
+---
+title: 'valuation-rank'
+sidebar_label: 'valuation-rank'
+sidebar_position: 11
+---
+
+# longbridge valuation-rank
+
+Track a stock's daily PE/PB/PS valuation percentile rank within its industry over a date range.
+
+## Basic Usage
+
+```bash
+longbridge valuation-rank TSLA.US
+```
+
+```
+  (day)
+Date                PE        PB        PS       Div
+────────────────────────────────────────────────────
+2026-04-08       19/49     35/49     37/49         -
+2026-04-09       19/49     35/49     37/49         -
+2026-04-10       19/49     35/49     36/49         -
+...
+```
+
+Each column shows `rank/total` — for example `19/49` means the stock ranks 19th out of 49 peers for that metric on that day.
+
+## Examples
+
+### Default (1 year)
+
+```bash
+longbridge valuation-rank TSLA.US
+longbridge valuation-rank AAPL.US
+```
+
+Returns daily valuation ranks for the past year (PE, PB, PS, dividend yield).
+
+### Custom date range
+
+```bash
+longbridge valuation-rank TSLA.US --start 20250101 --end 20251231
+longbridge valuation-rank 700.HK --start 20240101 --end 20241231
+```
+
+Date format is `YYYYMMDD`.
+
+### JSON output
+
+```bash
+longbridge valuation-rank TSLA.US --format json
+```
+
+Returns the same rank data as a JSON array, suitable for scripting or further analysis.

--- a/docs/en/docs/cli/ipo/_category_.json
+++ b/docs/en/docs/cli/ipo/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "IPO", "icon": "zap", "position": 9, "collapsed": true }

--- a/docs/en/docs/cli/ipo/index.md
+++ b/docs/en/docs/cli/ipo/index.md
@@ -1,0 +1,105 @@
+---
+title: 'ipo'
+sidebar_label: 'ipo'
+sidebar_position: 1
+---
+
+# longbridge ipo
+
+Track IPO listings, manage subscriptions, and review your IPO order history and profit/loss.
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| `subscriptions` | HK IPOs currently in filing or subscription stage |
+| `wait-listing` | HK IPOs in wait-listing (grey market) stage |
+| `listed` | Recently listed HK IPOs |
+| `calendar` | Full IPO calendar (HK + US) |
+| `detail` | Profile and timeline for a specific IPO symbol |
+| `orders` | Your IPO order history |
+| `profit-loss` | Your IPO profit/loss summary |
+| `us-subscriptions` | US IPOs currently in subscription stage |
+| `us-wait-listing` | US IPOs in wait-listing stage |
+| `us-listed` | Recently listed US IPOs |
+
+## Examples
+
+### IPO calendar
+
+```bash
+longbridge ipo calendar
+```
+
+```
+── HK ──
+| name       | symbol  | state   | sub_date   | sub_end_date | ipo_date   |
+|------------|---------|---------|------------|--------------|------------|
+| 翼菲科技   | 6871.HK | pending | 2026-05-07 | 2026-05-13   | 2026-05-17 |
+| 英派药业-B | 7630.HK | pending | 2026-05-04 | 2026-05-08   | 2026-05-12 |
+
+── US ──
+| name                       | symbol  | state   | ipo_date   |
+|----------------------------|---------|---------|------------|
+| Odyssey Therapeutics, Inc. | ODTX.US | pending | 2026-05-08 |
+```
+
+Shows the upcoming IPO schedule across HK and US markets.
+
+### Active subscriptions
+
+```bash
+longbridge ipo subscriptions
+```
+
+Lists HK IPOs currently open for subscription, including entrance fee, estimated subscription amount, financing rate, and max leverage.
+
+### Wait-listing (grey market)
+
+```bash
+longbridge ipo wait-listing
+```
+
+Lists HK IPOs that have closed subscription and are waiting for listing, with the indicative issue price range.
+
+### Recently listed
+
+```bash
+longbridge ipo listed
+```
+
+Shows recently listed IPOs with issue price, last price, and performance since IPO.
+
+### IPO detail
+
+```bash
+longbridge ipo detail 6871.HK
+```
+
+Shows the full IPO profile and listing timeline for a specific symbol.
+
+### Your IPO orders
+
+```bash
+longbridge ipo orders
+# Filter by status: 0=all, 1=subscribed, 2=debit-failed, 3=not-won, 4=won, 5=cancelled
+longbridge ipo orders --status 4
+# View detail for a specific order
+longbridge ipo orders detail 2452504
+```
+
+Lists your active and historical IPO subscription orders. Use `orders detail <id>` for full order details.
+
+### Profit/loss summary
+
+```bash
+longbridge ipo profit-loss
+# Filter by period: 1m | 3m | 6m | 1y | all
+longbridge ipo profit-loss --period 1y
+```
+
+Shows your IPO subscription profit/loss summary and per-stock breakdown for a given period.
+
+## Requirements
+
+OAuth account permission required for `orders` and `profit-loss`. See the [account permission setup](/docs/trade/) guide.

--- a/docs/en/docs/cli/release-notes.md
+++ b/docs/en/docs/cli/release-notes.md
@@ -7,6 +7,20 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.20.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.20.0)
+
+- **`ipo` command group** — comprehensive IPO tools: `subscriptions`, `wait-listing`, `listed`, `calendar`, `detail`, `orders`, `profit-loss` for HK market; `us-subscriptions`, `us-wait-listing`, `us-listed` for US market; `orders detail <id>` for full order detail
+- **`financial-statement`** — detailed, hierarchical financial statements (income statement, balance sheet, cash flow) with full line-item breakdown and YoY comparison; supports `--kind IS/BS/CF/ALL` and `--report af/saf/qf/cumul`
+- **`financial-report --latest`** — new flag to fetch the latest report summary (key indicators: revenue, net profit, EPS, ROE, total assets) without fetching the full statement
+- **`valuation-rank`** — daily PE/PB/PS industry percentile rank over a date range, showing `rank/total` for each metric
+- **`analyst-estimates`** — EPS analyst consensus estimates (high/low/mean/median, coverage count) across historical and forward periods
+- **`institution-rating --history` / `--industry-rank`** — new flags: `--history` shows how analyst ratings and price targets have changed over time; `--industry-rank` ranks all stocks in the same industry by analyst coverage
+- **`news search` / `topic search`** — keyword search across news articles and community topics
+- **`bank-cards`** — list bank cards linked to your account
+- **`withdrawals`** / **`deposits`** — view withdrawal and deposit history with date formatting and optional state/currency filters
+- **`portfolio short-margin`** — short-selling margin deposit details per position
+- **Fix: paper-trading account channel** — `auth status` and quote mall QR links now correctly reflect the account channel for paper-trading accounts (`lb_papertrading`), resolved from the access token JWT rather than hardcoded
+
 ### [v0.19.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.19.2)
 
 - **`finance-calendar` revamp** — restructured into subcommands (`report`, `dividend`, `split`, `ipo`, `macrodata`, `closed`); new `--filter watchlist|positions` scopes events to your watchlist or holdings

--- a/docs/zh-CN/docs/cli/account/bank-cards.md
+++ b/docs/zh-CN/docs/cli/account/bank-cards.md
@@ -1,0 +1,37 @@
+---
+title: 'bank-cards'
+sidebar_label: 'bank-cards'
+sidebar_position: 20
+---
+
+# longbridge bank-cards
+
+查看绑定至 Longbridge 账户的银行卡列表。
+
+## 基本用法
+
+```bash
+longbridge bank-cards
+```
+
+```
+| bank                 | account          | currency | swift    | region   | status |
+|----------------------|------------------|----------|----------|----------|--------|
+| DBS Bank             | 2712065366       | SGD      | DBSSSGSG | 新加坡   | active |
+| 招商银行             | 6212998605139779 | ALL      | CMBCHKHH | 香港     | active |
+```
+
+## 示例
+
+### 查看绑定银行卡
+
+```bash
+longbridge bank-cards
+longbridge bank-cards --format json
+```
+
+展示所有绑定银行卡的银行名称、账户号码（脱敏）、货币、SWIFT 代码及状态。
+
+## 权限要求
+
+需要 OAuth 账户权限。参见[账户权限设置](/zh-CN/docs/trade/)。

--- a/docs/zh-CN/docs/cli/account/deposits.md
+++ b/docs/zh-CN/docs/cli/account/deposits.md
@@ -1,0 +1,56 @@
+---
+title: 'deposits'
+sidebar_label: 'deposits'
+sidebar_position: 22
+---
+
+# longbridge deposits
+
+查看入金历史记录，支持按状态和货币筛选。
+
+## 基本用法
+
+```bash
+longbridge deposits
+```
+
+```
+Total: 3
+
+| id      | date                 | amount   | currency | type | state  |
+|---------|----------------------|----------|----------|------|--------|
+| 2096375 | 2026-04-30T07:57:49Z | 3000.00  | USD      | 电汇 | 已入账 |
+| 2036889 | 2026-03-27T02:54:49Z | 10000.00 | USD      | 电汇 | 已入账 |
+| 1980183 | 2026-03-02T02:32:11Z | 3132.60  | USD      | 电汇 | 已入账 |
+```
+
+## 示例
+
+### 查看全部入金记录
+
+```bash
+longbridge deposits
+```
+
+### 按状态筛选
+
+```bash
+# 0=待处理, 1=已入账, 2=失败
+longbridge deposits --states 1
+```
+
+### 按货币筛选
+
+```bash
+longbridge deposits --currencies HKD,USD
+```
+
+### 翻页
+
+```bash
+longbridge deposits --page 2 --count 50
+```
+
+## 权限要求
+
+需要 OAuth 账户权限。参见[账户权限设置](/zh-CN/docs/trade/)。

--- a/docs/zh-CN/docs/cli/account/portfolio.md
+++ b/docs/zh-CN/docs/cli/account/portfolio.md
@@ -45,6 +45,14 @@ longbridge portfolio --format json
 
 展示总资产价值、总盈亏及今日盈亏，以及各市场市值分布。
 
+### 融券保证金明细
+
+```bash
+longbridge portfolio short-margin
+```
+
+显示账户的融券保证金明细，包含各持仓的保证金要求及存入金额。
+
 ## 权限要求
 
 需要 OAuth 账户权限。参见[账户权限设置](/zh-CN/docs/trade/)。

--- a/docs/zh-CN/docs/cli/account/withdrawals.md
+++ b/docs/zh-CN/docs/cli/account/withdrawals.md
@@ -1,0 +1,42 @@
+---
+title: 'withdrawals'
+sidebar_label: 'withdrawals'
+sidebar_position: 21
+---
+
+# longbridge withdrawals
+
+查看出金历史记录。
+
+## 基本用法
+
+```bash
+longbridge withdrawals
+```
+
+```
+Total: 5
+
+| id      | date                 | amount   | currency | type | state  |
+|---------|----------------------|----------|----------|------|--------|
+| 2096375 | 2026-04-30T07:57:49Z | 3000.00  | USD      | 电汇 | 已入账 |
+| 2036889 | 2026-03-27T02:54:49Z | 10000.00 | USD      | 电汇 | 已入账 |
+```
+
+## 示例
+
+### 查看出金记录
+
+```bash
+longbridge withdrawals
+```
+
+### 翻页
+
+```bash
+longbridge withdrawals --page 2 --count 50
+```
+
+## 权限要求
+
+需要 OAuth 账户权限。参见[账户权限设置](/zh-CN/docs/trade/)。

--- a/docs/zh-CN/docs/cli/content/news.md
+++ b/docs/zh-CN/docs/cli/content/news.md
@@ -45,3 +45,12 @@ longbridge news detail 282276051
 ```
 
 通过 ID 获取单篇文章的完整 Markdown 内容。文章 ID 来自列表输出的 `id` 字段。
+
+### 按关键词搜索资讯
+
+```bash
+longbridge news search "AI 股票"
+longbridge news search TSLA --count 10
+```
+
+按关键词全局搜索资讯文章。使用 `--count` 控制返回条数（默认 20）。

--- a/docs/zh-CN/docs/cli/content/topic.md
+++ b/docs/zh-CN/docs/cli/content/topic.md
@@ -35,6 +35,15 @@ longbridge topic NVDA.US
 
 列出与该标的相关的社区帖子，包含标题、摘要及互动数据。
 
+### 按关键词搜索话题
+
+```bash
+longbridge topic search TSLA
+longbridge topic search "AI 股票" --count 10
+```
+
+按关键词搜索社区话题。返回匹配帖子的标题、作者摘要及互动数据。使用 `--count` 控制返回条数（默认 20）。
+
 ### 阅读帖子完整内容
 
 ```bash

--- a/docs/zh-CN/docs/cli/fundamentals/analyst-estimates.md
+++ b/docs/zh-CN/docs/cli/fundamentals/analyst-estimates.md
@@ -1,0 +1,46 @@
+---
+title: 'analyst-estimates'
+sidebar_label: 'analyst-estimates'
+sidebar_position: 12
+---
+
+# longbridge analyst-estimates
+
+查看个股的历史及预测 EPS 分析师一致性预期，包含高/低/均值/中位数及覆盖分析师数量。
+
+## 基本用法
+
+```bash
+longbridge analyst-estimates TSLA.US
+```
+
+```
+estimate:
+| currency | day        | high | low  | mean | median | num | value |
+|----------|------------|------|------|------|--------|-----|-------|
+| USD      | 2026-03-31 | 0.24 | 0.07 | 0.15 | 0.13   | 8   |       |
+| USD      | 2026-06-30 | 0.38 | 0.09 | 0.21 | 0.18   | 8   |       |
+...
+```
+
+`value` 有值时表示实际已披露的 EPS；为空表示该期尚未公布。
+
+## 示例
+
+### EPS 预期
+
+```bash
+longbridge analyst-estimates TSLA.US
+longbridge analyst-estimates AAPL.US
+longbridge analyst-estimates NVDA.US
+```
+
+返回历史及未来各期的分析师 EPS 一致预期，含离散度（高/低）和覆盖数。
+
+### JSON 输出
+
+```bash
+longbridge analyst-estimates TSLA.US --format json
+```
+
+以 JSON 格式返回完整预期数据，适合程序化使用。

--- a/docs/zh-CN/docs/cli/fundamentals/financial-statement.md
+++ b/docs/zh-CN/docs/cli/fundamentals/financial-statement.md
@@ -1,0 +1,83 @@
+---
+title: 'financial-statement'
+sidebar_label: 'financial-statement'
+sidebar_position: 3
+---
+
+# longbridge financial-statement
+
+获取上市公司完整的逐行财务报表——利润表、资产负债表或现金流量表。
+
+## 基本用法
+
+```bash
+longbridge financial-statement TSLA.US --kind IS
+```
+
+```
+  (in USD)
+                                 Q1 2026     Q4 2025     Q3 2025     Q2 2025     Q1 2025      YoY
+─────────────────────────────────────────────────────────────────────────────────────────────────
+
+收入
+  总营业收入                      22.39B      24.90B      28.09B      22.50B      19.34B   -10.1%
+    主营业务收入                  22.39B      24.90B      28.09B      22.50B      19.34B   -10.1%
+
+成本
+  营业成本                        17.67B      19.89B      23.04B      18.62B      16.18B   -11.2%
+  毛利润                           4.72B       5.01B       5.05B       3.88B       3.15B    -5.8%
+...
+```
+
+## 示例
+
+### 季度利润表
+
+```bash
+longbridge financial-statement TSLA.US --kind IS --report qf
+longbridge financial-statement AAPL.US --kind IS --report qf
+```
+
+返回带 YoY 对比的季度利润表。
+
+### 年度资产负债表
+
+```bash
+longbridge financial-statement TSLA.US --kind BS --report af
+longbridge financial-statement 700.HK --kind BS --report af
+```
+
+返回含资产、负债、股东权益明细的完整年度资产负债表。
+
+### 现金流量表
+
+```bash
+longbridge financial-statement NVDA.US --kind CF
+```
+
+返回经营、投资和融资活动的现金流量。
+
+### 获取全部三张报表
+
+```bash
+longbridge financial-statement AAPL.US
+```
+
+一次性获取三张报表，等同于 `--kind ALL`。
+
+### 累计期间
+
+```bash
+longbridge financial-statement TSLA.US --kind IS --report cumul
+```
+
+返回年初至今的累计利润表。
+
+### 报告期选项
+
+| `--report` | 说明 |
+|---|---|
+| `af` | 年度（默认） |
+| `saf` | 半年度 |
+| `qf` | 季度 |
+| `cumul` | 累计（年初至今） |

--- a/docs/zh-CN/docs/cli/fundamentals/institution-rating.md
+++ b/docs/zh-CN/docs/cli/fundamentals/institution-rating.md
@@ -50,6 +50,40 @@ longbridge institution-rating detail TSLA.US
 
 `detail` 子命令列出按周统计的历史评级分布及各分析师目标价，便于追踪情绪随时间的变化趋势。
 
+### 评级及目标价历史
+
+```bash
+longbridge institution-rating TSLA.US --history
+```
+
+展示分析师评级分布与一致性目标价随时间的变化情况，便于追踪分析师情绪的转变。
+
+### 行业排名
+
+```bash
+longbridge institution-rating TSLA.US --industry-rank
+# 翻页
+longbridge institution-rating TSLA.US --industry-rank --page 2 --limit 20
+```
+
+```
+| key             | value      |
+|-----------------|------------|
+| industry_name   | 汽车制造商 |
+| industry_rank   | 1          |
+| industry_mean   | 10         |
+| industry_total  | 30         |
+
+items:
+| symbol   | name   | buy | hold | sell | total | rank |
+|----------|--------|-----|------|------|-------|------|
+| TSLA.US  | 特斯拉 | 23  | 17   | 10   | 51    | 1    |
+| GM.US    | 通用汽车| 20 | 5    | 1    | 27    | 2    |
+...
+```
+
+将同行业所有股票按分析师覆盖数量排名，直观了解你的持仓在行业内的研究关注度。
+
 ### JSON 输出用于监控
 
 ```bash

--- a/docs/zh-CN/docs/cli/fundamentals/valuation-rank.md
+++ b/docs/zh-CN/docs/cli/fundamentals/valuation-rank.md
@@ -1,0 +1,54 @@
+---
+title: 'valuation-rank'
+sidebar_label: 'valuation-rank'
+sidebar_position: 11
+---
+
+# longbridge valuation-rank
+
+追踪个股在行业内的每日 PE/PB/PS 估值百分位排名。
+
+## 基本用法
+
+```bash
+longbridge valuation-rank TSLA.US
+```
+
+```
+  (day)
+Date                PE        PB        PS       Div
+────────────────────────────────────────────────────
+2026-04-08       19/49     35/49     37/49         -
+2026-04-09       19/49     35/49     37/49         -
+...
+```
+
+每列显示 `排名/总数`，例如 `19/49` 表示当天该股在 49 个同业股中排第 19 位。
+
+## 示例
+
+### 默认（近 1 年）
+
+```bash
+longbridge valuation-rank TSLA.US
+longbridge valuation-rank AAPL.US
+```
+
+返回过去一年的每日估值排名（PE、PB、PS、股息率）。
+
+### 自定义日期范围
+
+```bash
+longbridge valuation-rank TSLA.US --start 20250101 --end 20251231
+longbridge valuation-rank 700.HK --start 20240101 --end 20241231
+```
+
+日期格式为 `YYYYMMDD`。
+
+### JSON 输出
+
+```bash
+longbridge valuation-rank TSLA.US --format json
+```
+
+以 JSON 数组形式返回排名数据，适合脚本处理。

--- a/docs/zh-CN/docs/cli/ipo/_category_.json
+++ b/docs/zh-CN/docs/cli/ipo/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "IPO", "icon": "zap", "position": 9, "collapsed": true }

--- a/docs/zh-CN/docs/cli/ipo/index.md
+++ b/docs/zh-CN/docs/cli/ipo/index.md
@@ -1,0 +1,105 @@
+---
+title: 'ipo'
+sidebar_label: 'ipo'
+sidebar_position: 1
+---
+
+# longbridge ipo
+
+追踪 IPO 上市动态、管理认购，并查看 IPO 订单历史和盈亏情况。
+
+## 子命令
+
+| 子命令 | 说明 |
+|---|---|
+| `subscriptions` | 港股当前处于招股或认购阶段的 IPO |
+| `wait-listing` | 港股等待上市（灰市）阶段的 IPO |
+| `listed` | 近期已上市的港股 IPO |
+| `calendar` | 完整 IPO 日历（港股 + 美股） |
+| `detail` | 指定标的的 IPO 详情及时间线 |
+| `orders` | 你的 IPO 订单历史 |
+| `profit-loss` | 你的 IPO 认购盈亏汇总 |
+| `us-subscriptions` | 美股当前处于认购阶段的 IPO |
+| `us-wait-listing` | 美股等待上市阶段的 IPO |
+| `us-listed` | 近期已上市的美股 IPO |
+
+## 示例
+
+### IPO 日历
+
+```bash
+longbridge ipo calendar
+```
+
+```
+── HK ──
+| name       | symbol  | state   | sub_date   | sub_end_date | ipo_date   |
+|------------|---------|---------|------------|--------------|------------|
+| 翼菲科技   | 6871.HK | pending | 2026-05-07 | 2026-05-13   | 2026-05-17 |
+| 英派药业-B | 7630.HK | pending | 2026-05-04 | 2026-05-08   | 2026-05-12 |
+
+── US ──
+| name                       | symbol  | state   | ipo_date   |
+|----------------------------|---------|---------|------------|
+| Odyssey Therapeutics, Inc. | ODTX.US | pending | 2026-05-08 |
+```
+
+展示港股和美股即将上市的 IPO 日程。
+
+### 在招 IPO
+
+```bash
+longbridge ipo subscriptions
+```
+
+列出当前开放认购的港股 IPO，包括入场费、预计认购额、融资利率及最高杠杆。
+
+### 暗盘阶段
+
+```bash
+longbridge ipo wait-listing
+```
+
+列出已截止认购、等待上市的港股 IPO，显示参考发行价区间。
+
+### 近期上市
+
+```bash
+longbridge ipo listed
+```
+
+显示近期上市的 IPO，含发行价、最新价及上市以来涨跌幅。
+
+### IPO 详情
+
+```bash
+longbridge ipo detail 6871.HK
+```
+
+查看指定标的的完整 IPO 档案及上市时间线。
+
+### 我的 IPO 订单
+
+```bash
+longbridge ipo orders
+# 按状态筛选：0=全部, 1=已认购, 2=扣款失败, 3=未中签, 4=已中签, 5=已撤单
+longbridge ipo orders --status 4
+# 查看单笔订单详情
+longbridge ipo orders detail 2452504
+```
+
+列出你的 IPO 认购订单（当前及历史）。使用 `orders detail <id>` 查看完整订单详情。
+
+### 认购盈亏汇总
+
+```bash
+longbridge ipo profit-loss
+# 按时间段筛选：1m | 3m | 6m | 1y | all
+longbridge ipo profit-loss --period 1y
+```
+
+显示指定时间段内的 IPO 认购盈亏汇总及逐标的明细。
+
+## 权限要求
+
+`orders` 和 `profit-loss` 需要 OAuth 账户权限。参见[账户权限设置](/zh-CN/docs/trade/)。

--- a/docs/zh-CN/docs/cli/release-notes.md
+++ b/docs/zh-CN/docs/cli/release-notes.md
@@ -7,6 +7,20 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.20.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.20.0)
+
+- **`ipo` 命令组** — 完整 IPO 工具：港股支持 `subscriptions`（在招）、`wait-listing`（暗盘）、`listed`（近期上市）、`calendar`（日历）、`detail`（详情）、`orders`（订单）、`profit-loss`（盈亏）；美股支持 `us-subscriptions`、`us-wait-listing`、`us-listed`
+- **`financial-statement`** — 完整逐行财务报表（利润表/资产负债表/现金流量表），含层级结构与 YoY 对比；支持 `--kind IS/BS/CF/ALL` 和 `--report af/saf/qf/cumul`
+- **`financial-report --latest`** — 新增 `--latest` 参数，快速获取最新财报关键指标摘要（营收、净利润、EPS、ROE、总资产）
+- **`valuation-rank`** — 每日 PE/PB/PS 行业百分位排名，以 `排名/总数` 形式展示，支持自定义日期范围
+- **`analyst-estimates`** — 分析师 EPS 一致性预期（高/低/均值/中位数、覆盖数），含历史与未来各期数据
+- **`institution-rating --history` / `--industry-rank`** — 新增参数：`--history` 查看评级及目标价随时间的变化；`--industry-rank` 查看行业内所有股票的分析师覆盖排名
+- **`news search` / `topic search`** — 按关键词搜索资讯和社区话题
+- **`bank-cards`** — 查看账户绑定的银行卡列表
+- **`withdrawals`** / **`deposits`** — 查看出入金历史记录，支持按状态和货币筛选
+- **`portfolio short-margin`** — 融券保证金逐仓明细
+- **修复：模拟盘账户渠道识别** — `auth status` 及行情商城二维码链接现在能正确识别模拟盘账户（`lb_papertrading`）的账户渠道，从 Access Token JWT 动态解析，不再硬编码
+
 ### [v0.19.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.19.2)
 
 - **`finance-calendar` 重构** — 改为子命令结构（`report`、`dividend`、`split`、`ipo`、`macrodata`、`closed`）；新增 `--filter watchlist|positions` 按自选股或持仓筛选事件

--- a/docs/zh-HK/docs/cli/account/bank-cards.md
+++ b/docs/zh-HK/docs/cli/account/bank-cards.md
@@ -1,0 +1,37 @@
+---
+title: 'bank-cards'
+sidebar_label: 'bank-cards'
+sidebar_position: 20
+---
+
+# longbridge bank-cards
+
+查看綁定至 Longbridge 賬戶的銀行卡列表。
+
+## 基本用法
+
+```bash
+longbridge bank-cards
+```
+
+```
+| bank                 | account          | currency | swift    | region   | status |
+|----------------------|------------------|----------|----------|----------|--------|
+| DBS Bank             | 2712065366       | SGD      | DBSSSGSG | 新加坡   | active |
+| 招商銀行             | 6212998605139779 | ALL      | CMBCHKHH | 香港     | active |
+```
+
+## 示例
+
+### 查看綁定銀行卡
+
+```bash
+longbridge bank-cards
+longbridge bank-cards --format json
+```
+
+展示所有綁定銀行卡的銀行名稱、賬戶號碼（脫敏）、貨幣、SWIFT 代碼及狀態。
+
+## 權限要求
+
+需要 OAuth 賬戶權限。參見[賬戶權限設置](/zh-HK/docs/trade/)。

--- a/docs/zh-HK/docs/cli/account/deposits.md
+++ b/docs/zh-HK/docs/cli/account/deposits.md
@@ -1,0 +1,56 @@
+---
+title: 'deposits'
+sidebar_label: 'deposits'
+sidebar_position: 22
+---
+
+# longbridge deposits
+
+查看入金歷史記錄，支持按狀態和貨幣篩選。
+
+## 基本用法
+
+```bash
+longbridge deposits
+```
+
+```
+Total: 3
+
+| id      | date                 | amount   | currency | type | state  |
+|---------|----------------------|----------|----------|------|--------|
+| 2096375 | 2026-04-30T07:57:49Z | 3000.00  | USD      | 電匯 | 已入賬 |
+| 2036889 | 2026-03-27T02:54:49Z | 10000.00 | USD      | 電匯 | 已入賬 |
+| 1980183 | 2026-03-02T02:32:11Z | 3132.60  | USD      | 電匯 | 已入賬 |
+```
+
+## 示例
+
+### 查看全部入金記錄
+
+```bash
+longbridge deposits
+```
+
+### 按狀態篩選
+
+```bash
+# 0=待處理, 1=已入賬, 2=失敗
+longbridge deposits --states 1
+```
+
+### 按貨幣篩選
+
+```bash
+longbridge deposits --currencies HKD,USD
+```
+
+### 翻頁
+
+```bash
+longbridge deposits --page 2 --count 50
+```
+
+## 權限要求
+
+需要 OAuth 賬戶權限。參見[賬戶權限設置](/zh-HK/docs/trade/)。

--- a/docs/zh-HK/docs/cli/account/portfolio.md
+++ b/docs/zh-HK/docs/cli/account/portfolio.md
@@ -45,6 +45,14 @@ longbridge portfolio --format json
 
 展示總資產價值、總盈虧及今日盈虧，以及各市場市值分佈。
 
+### 融券保證金明細
+
+```bash
+longbridge portfolio short-margin
+```
+
+顯示帳戶的融券保證金明細，包含各持倉的保證金要求及存入金額。
+
 ## 權限要求
 
 需要 OAuth 帳戶權限。參見[帳戶權限設置](/zh-HK/docs/trade/)。

--- a/docs/zh-HK/docs/cli/account/withdrawals.md
+++ b/docs/zh-HK/docs/cli/account/withdrawals.md
@@ -1,0 +1,42 @@
+---
+title: 'withdrawals'
+sidebar_label: 'withdrawals'
+sidebar_position: 21
+---
+
+# longbridge withdrawals
+
+查看出金歷史記錄。
+
+## 基本用法
+
+```bash
+longbridge withdrawals
+```
+
+```
+Total: 5
+
+| id      | date                 | amount   | currency | type | state  |
+|---------|----------------------|----------|----------|------|--------|
+| 2096375 | 2026-04-30T07:57:49Z | 3000.00  | USD      | 電匯 | 已入賬 |
+| 2036889 | 2026-03-27T02:54:49Z | 10000.00 | USD      | 電匯 | 已入賬 |
+```
+
+## 示例
+
+### 查看出金記錄
+
+```bash
+longbridge withdrawals
+```
+
+### 翻頁
+
+```bash
+longbridge withdrawals --page 2 --count 50
+```
+
+## 權限要求
+
+需要 OAuth 賬戶權限。參見[賬戶權限設置](/zh-HK/docs/trade/)。

--- a/docs/zh-HK/docs/cli/content/news.md
+++ b/docs/zh-HK/docs/cli/content/news.md
@@ -45,3 +45,12 @@ longbridge news detail 282276051
 ```
 
 透過 ID 取得單篇文章的完整 Markdown 內容。文章 ID 來自列表輸出的 `id` 字段。
+
+### 按關鍵詞搜尋資訊
+
+```bash
+longbridge news search "AI 股票"
+longbridge news search TSLA --count 10
+```
+
+按關鍵詞全局搜尋資訊文章。使用 `--count` 控制返回條數（預設 20）。

--- a/docs/zh-HK/docs/cli/content/topic.md
+++ b/docs/zh-HK/docs/cli/content/topic.md
@@ -35,6 +35,15 @@ longbridge topic NVDA.US
 
 列出與該標的相關的社區帖子，包含標題、摘要及互動數據。
 
+### 按關鍵詞搜尋話題
+
+```bash
+longbridge topic search TSLA
+longbridge topic search "AI 股票" --count 10
+```
+
+按關鍵詞搜尋社區話題。返回匹配帖子的標題、作者摘要及互動數據。使用 `--count` 控制返回條數（預設 20）。
+
 ### 閱讀帖子完整內容
 
 ```bash

--- a/docs/zh-HK/docs/cli/fundamentals/analyst-estimates.md
+++ b/docs/zh-HK/docs/cli/fundamentals/analyst-estimates.md
@@ -1,0 +1,46 @@
+---
+title: 'analyst-estimates'
+sidebar_label: 'analyst-estimates'
+sidebar_position: 12
+---
+
+# longbridge analyst-estimates
+
+查看個股的歷史及預測 EPS 分析師一致性預期，包含高/低/均值/中位數及覆蓋分析師數量。
+
+## 基本用法
+
+```bash
+longbridge analyst-estimates TSLA.US
+```
+
+```
+estimate:
+| currency | day        | high | low  | mean | median | num | value |
+|----------|------------|------|------|------|--------|-----|-------|
+| USD      | 2026-03-31 | 0.24 | 0.07 | 0.15 | 0.13   | 8   |       |
+| USD      | 2026-06-30 | 0.38 | 0.09 | 0.21 | 0.18   | 8   |       |
+...
+```
+
+`value` 有值時表示實際已披露的 EPS；為空表示該期尚未公布。
+
+## 示例
+
+### EPS 預期
+
+```bash
+longbridge analyst-estimates TSLA.US
+longbridge analyst-estimates AAPL.US
+longbridge analyst-estimates NVDA.US
+```
+
+返回歷史及未來各期的分析師 EPS 一致預期，含離散度（高/低）和覆蓋數。
+
+### JSON 輸出
+
+```bash
+longbridge analyst-estimates TSLA.US --format json
+```
+
+以 JSON 格式返回完整預期數據，適合程式化使用。

--- a/docs/zh-HK/docs/cli/fundamentals/financial-statement.md
+++ b/docs/zh-HK/docs/cli/fundamentals/financial-statement.md
@@ -1,0 +1,83 @@
+---
+title: 'financial-statement'
+sidebar_label: 'financial-statement'
+sidebar_position: 3
+---
+
+# longbridge financial-statement
+
+獲取上市公司完整的逐行財務報表——損益表、資產負債表或現金流量表。
+
+## 基本用法
+
+```bash
+longbridge financial-statement TSLA.US --kind IS
+```
+
+```
+  (in USD)
+                                 Q1 2026     Q4 2025     Q3 2025     Q2 2025     Q1 2025      YoY
+─────────────────────────────────────────────────────────────────────────────────────────────────
+
+收入
+  總營業收入                      22.39B      24.90B      28.09B      22.50B      19.34B   -10.1%
+    主營業務收入                  22.39B      24.90B      28.09B      22.50B      19.34B   -10.1%
+
+成本
+  營業成本                        17.67B      19.89B      23.04B      18.62B      16.18B   -11.2%
+  毛利潤                           4.72B       5.01B       5.05B       3.88B       3.15B    -5.8%
+...
+```
+
+## 示例
+
+### 季度損益表
+
+```bash
+longbridge financial-statement TSLA.US --kind IS --report qf
+longbridge financial-statement AAPL.US --kind IS --report qf
+```
+
+返回帶 YoY 對比的季度損益表。
+
+### 年度資產負債表
+
+```bash
+longbridge financial-statement TSLA.US --kind BS --report af
+longbridge financial-statement 700.HK --kind BS --report af
+```
+
+返回含資產、負債、股東權益明細的完整年度資產負債表。
+
+### 現金流量表
+
+```bash
+longbridge financial-statement NVDA.US --kind CF
+```
+
+返回經營、投資和融資活動的現金流量。
+
+### 獲取全部三張報表
+
+```bash
+longbridge financial-statement AAPL.US
+```
+
+一次性獲取三張報表，等同於 `--kind ALL`。
+
+### 累計期間
+
+```bash
+longbridge financial-statement TSLA.US --kind IS --report cumul
+```
+
+返回年初至今的累計損益表。
+
+### 報告期選項
+
+| `--report` | 說明 |
+|---|---|
+| `af` | 年度（預設） |
+| `saf` | 半年度 |
+| `qf` | 季度 |
+| `cumul` | 累計（年初至今） |

--- a/docs/zh-HK/docs/cli/fundamentals/institution-rating.md
+++ b/docs/zh-HK/docs/cli/fundamentals/institution-rating.md
@@ -50,6 +50,24 @@ longbridge institution-rating detail TSLA.US
 
 `detail` 子命令列出按周統計的歷史評級分佈及各分析師目標價，便於追蹤情緒隨時間的變化趨勢。
 
+### 評級及目標價歷史
+
+```bash
+longbridge institution-rating TSLA.US --history
+```
+
+展示分析師評級分佈與一致性目標價隨時間的變化情況，便於追蹤分析師情緒的轉變。
+
+### 行業排名
+
+```bash
+longbridge institution-rating TSLA.US --industry-rank
+# 翻頁
+longbridge institution-rating TSLA.US --industry-rank --page 2 --limit 20
+```
+
+將同行業所有股票按分析師覆蓋數量排名，直觀了解持倉在行業內的研究關注度。
+
 ### JSON 輸出用於監控
 
 ```bash

--- a/docs/zh-HK/docs/cli/fundamentals/valuation-rank.md
+++ b/docs/zh-HK/docs/cli/fundamentals/valuation-rank.md
@@ -1,0 +1,54 @@
+---
+title: 'valuation-rank'
+sidebar_label: 'valuation-rank'
+sidebar_position: 11
+---
+
+# longbridge valuation-rank
+
+追蹤個股在行業內的每日 PE/PB/PS 估值百分位排名。
+
+## 基本用法
+
+```bash
+longbridge valuation-rank TSLA.US
+```
+
+```
+  (day)
+Date                PE        PB        PS       Div
+────────────────────────────────────────────────────
+2026-04-08       19/49     35/49     37/49         -
+2026-04-09       19/49     35/49     37/49         -
+...
+```
+
+每欄顯示「排名/總數」，例如 `19/49` 表示當天該股在 49 個同業股中排第 19 位。
+
+## 示例
+
+### 預設（近 1 年）
+
+```bash
+longbridge valuation-rank TSLA.US
+longbridge valuation-rank AAPL.US
+```
+
+返回過去一年的每日估值排名（PE、PB、PS、股息率）。
+
+### 自訂日期範圍
+
+```bash
+longbridge valuation-rank TSLA.US --start 20250101 --end 20251231
+longbridge valuation-rank 700.HK --start 20240101 --end 20241231
+```
+
+日期格式為 `YYYYMMDD`。
+
+### JSON 輸出
+
+```bash
+longbridge valuation-rank TSLA.US --format json
+```
+
+以 JSON 陣列形式返回排名數據，適合腳本處理。

--- a/docs/zh-HK/docs/cli/ipo/_category_.json
+++ b/docs/zh-HK/docs/cli/ipo/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "IPO", "icon": "zap", "position": 9, "collapsed": true }

--- a/docs/zh-HK/docs/cli/ipo/index.md
+++ b/docs/zh-HK/docs/cli/ipo/index.md
@@ -1,0 +1,105 @@
+---
+title: 'ipo'
+sidebar_label: 'ipo'
+sidebar_position: 1
+---
+
+# longbridge ipo
+
+追蹤 IPO 上市動態、管理認購，並查看 IPO 訂單歷史和盈虧情況。
+
+## 子命令
+
+| 子命令 | 說明 |
+|---|---|
+| `subscriptions` | 港股當前處於招股或認購階段的 IPO |
+| `wait-listing` | 港股等待上市（暗盤）階段的 IPO |
+| `listed` | 近期已上市的港股 IPO |
+| `calendar` | 完整 IPO 日曆（港股 + 美股） |
+| `detail` | 指定標的的 IPO 詳情及時間線 |
+| `orders` | 你的 IPO 訂單歷史 |
+| `profit-loss` | 你的 IPO 認購盈虧彙總 |
+| `us-subscriptions` | 美股當前處於認購階段的 IPO |
+| `us-wait-listing` | 美股等待上市階段的 IPO |
+| `us-listed` | 近期已上市的美股 IPO |
+
+## 示例
+
+### IPO 日曆
+
+```bash
+longbridge ipo calendar
+```
+
+```
+── HK ──
+| name       | symbol  | state   | sub_date   | sub_end_date | ipo_date   |
+|------------|---------|---------|------------|--------------|------------|
+| 翼菲科技   | 6871.HK | pending | 2026-05-07 | 2026-05-13   | 2026-05-17 |
+| 英派药业-B | 7630.HK | pending | 2026-05-04 | 2026-05-08   | 2026-05-12 |
+
+── US ──
+| name                       | symbol  | state   | ipo_date   |
+|----------------------------|---------|---------|------------|
+| Odyssey Therapeutics, Inc. | ODTX.US | pending | 2026-05-08 |
+```
+
+展示港股和美股即將上市的 IPO 日程。
+
+### 在招 IPO
+
+```bash
+longbridge ipo subscriptions
+```
+
+列出當前開放認購的港股 IPO，包括入場費、預計認購額、融資利率及最高槓桿。
+
+### 暗盤階段
+
+```bash
+longbridge ipo wait-listing
+```
+
+列出已截止認購、等待上市的港股 IPO，顯示參考發行價區間。
+
+### 近期上市
+
+```bash
+longbridge ipo listed
+```
+
+顯示近期上市的 IPO，含發行價、最新價及上市以來漲跌幅。
+
+### IPO 詳情
+
+```bash
+longbridge ipo detail 6871.HK
+```
+
+查看指定標的的完整 IPO 檔案及上市時間線。
+
+### 我的 IPO 訂單
+
+```bash
+longbridge ipo orders
+# 按狀態篩選：0=全部, 1=已認購, 2=扣款失敗, 3=未中籤, 4=已中籤, 5=已撤單
+longbridge ipo orders --status 4
+# 查看單筆訂單詳情
+longbridge ipo orders detail 2452504
+```
+
+列出你的 IPO 認購訂單（當前及歷史）。使用 `orders detail <id>` 查看完整訂單詳情。
+
+### 認購盈虧彙總
+
+```bash
+longbridge ipo profit-loss
+# 按時間段篩選：1m | 3m | 6m | 1y | all
+longbridge ipo profit-loss --period 1y
+```
+
+顯示指定時間段內的 IPO 認購盈虧彙總及逐標的明細。
+
+## 權限要求
+
+`orders` 和 `profit-loss` 需要 OAuth 賬戶權限。參見[賬戶權限設置](/zh-HK/docs/trade/)。

--- a/docs/zh-HK/docs/cli/release-notes.md
+++ b/docs/zh-HK/docs/cli/release-notes.md
@@ -7,6 +7,20 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.20.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.20.0)
+
+- **`ipo` 指令組** — 完整 IPO 工具：港股支持 `subscriptions`（招股中）、`wait-listing`（暗盤）、`listed`（近期上市）、`calendar`（日曆）、`detail`（詳情）、`orders`（訂單）、`profit-loss`（盈虧）；美股支持 `us-subscriptions`、`us-wait-listing`、`us-listed`
+- **`financial-statement`** — 完整逐行財務報表（損益表/資產負債表/現金流量表），含層級結構與 YoY 對比；支持 `--kind IS/BS/CF/ALL` 和 `--report af/saf/qf/cumul`
+- **`financial-report --latest`** — 新增 `--latest` 參數，快速獲取最新財報關鍵指標摘要（營收、淨利潤、EPS、ROE、總資產）
+- **`valuation-rank`** — 每日 PE/PB/PS 行業百分位排名，以「排名/總數」形式展示，支持自訂日期範圍
+- **`analyst-estimates`** — 分析師 EPS 一致性預期（高/低/均值/中位數、覆蓋數），含歷史與未來各期數據
+- **`institution-rating --history` / `--industry-rank`** — 新增參數：`--history` 查看評級及目標價隨時間的變化；`--industry-rank` 查看行業內所有股票的分析師覆蓋排名
+- **`news search` / `topic search`** — 按關鍵詞搜尋資訊和社區話題
+- **`bank-cards`** — 查看賬戶綁定的銀行卡列表
+- **`withdrawals`** / **`deposits`** — 查看出入金歷史記錄，支持按狀態和貨幣篩選
+- **`portfolio short-margin`** — 融券保證金逐倉明細
+- **修正：模擬盤賬戶渠道識別** — `auth status` 及行情商城二維碼鏈接現在能正確識別模擬盤賬戶（`lb_papertrading`）的渠道，從 Access Token JWT 動態解析，不再硬編碼
+
 ### [v0.19.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.19.2)
 
 - **`finance-calendar` 重構** — 改為子命令結構（`report`、`dividend`、`split`、`ipo`、`macrodata`、`closed`）；新增 `--filter watchlist|positions` 按自選股或持倉篩選事件


### PR DESCRIPTION
## Summary

- New `ipo` command group docs (subscriptions, wait-listing, listed, calendar, detail, orders, profit-loss; HK + US variants)
- New `financial-statement` command doc (detailed hierarchical IS/BS/CF with YoY)
- New `valuation-rank` command doc (daily PE/PB/PS industry percentile rank)
- New `analyst-estimates` command doc (EPS consensus estimates)
- New `bank-cards`, `withdrawals`, `deposits` account command docs
- Updated `institution-rating` with `--history` and `--industry-rank` examples
- Updated `news` and `topic` with `search` subcommand examples
- Updated `portfolio` with `short-margin` subcommand
- Added v0.20.0 Release Notes (en/zh-CN/zh-HK)

All documentation is trilingual (en / zh-CN / zh-HK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)