### PR TITLE
docs(skill): update install guide with correct repo and Claude Code plugin

### DIFF
--- a/docs/en/skill/install/index.md
+++ b/docs/en/skill/install/index.md
@@ -18,15 +18,26 @@ Once installed, you can say things like this to your AI assistant and get real a
 
 ## Step 1 — Install the Skill
 
-The Skill is a set of instruction files that tell your AI assistant what Longbridge can do. Two ways to install:
+The Skill is a set of instruction files that tell your AI assistant what Longbridge can do. Three ways to install:
 
-**Via npx / bunx (recommended, global install):**
+**Via Claude Code plugin (recommended for Claude Code users):**
+
+In Claude Code, run these two commands:
+
+```text
+/plugin marketplace add longbridge/skills
+/plugin install longbridge@longbridge-skills
+```
+
+This installs all Longbridge skills through the Claude Code plugin system and keeps them up to date automatically.
+
+**Via npx / bunx (global install):**
 
 ```bash
 # Node.js
-npx skills add longbridge/developers -g -y
+npx skills add longbridge/skills -g
 # Bun
-bunx skills add longbridge/developers -g -y
+bunx skills add longbridge/skills -g
 ```
 
 > Requires [Node.js](https://nodejs.org) or [Bun](https://bun.sh).

--- a/docs/zh-CN/skill/install/index.md
+++ b/docs/zh-CN/skill/install/index.md
@@ -18,15 +18,26 @@ description: 在 OpenClaw、Claude Code、Cursor、Codex 等 AI 工具中安装 
 
 ## 第一步：安装 Skill
 
-Skill 是一组指令文件，告诉 AI 助手 Longbridge 能做什么。安装方式有两种：
+Skill 是一组指令文件，告诉 AI 助手 Longbridge 能做什么。安装方式有三种：
 
-**通过 npx / bunx（推荐，全局安装）：**
+**通过 Claude Code 插件安装（Claude Code 用户推荐）：**
+
+在 Claude Code 中依次执行以下两条命令：
+
+```text
+/plugin marketplace add longbridge/skills
+/plugin install longbridge@longbridge-skills
+```
+
+此方式通过 Claude Code 插件系统安装全部 Longbridge Skill，并可自动保持最新版本。
+
+**通过 npx / bunx（全局安装）：**
 
 ```bash
 # Node.js
-npx skills add longbridge/developers -g -y
+npx skills add longbridge/skills -g
 # Bun
-bunx skills add longbridge/developers -g -y
+bunx skills add longbridge/skills -g
 ```
 
 > 需要 [Node.js](https://nodejs.org) 或 [Bun](https://bun.sh) 环境。

--- a/docs/zh-HK/skill/install/index.md
+++ b/docs/zh-HK/skill/install/index.md
@@ -18,15 +18,26 @@ description: 在 OpenClaw、Claude Code、Cursor、Codex 等 AI 工具中安裝 
 
 ## 第一步：安裝 Skill
 
-Skill 是一組指令文件，告訴 AI 助手 Longbridge 能做什麼。安裝方式有兩種：
+Skill 是一組指令文件，告訴 AI 助手 Longbridge 能做什麼。安裝方式有三種：
 
-**通過 npx / bunx（推薦，全局安裝）：**
+**通過 Claude Code 插件安裝（Claude Code 用戶推薦）：**
+
+在 Claude Code 中依次執行以下兩條命令：
+
+```text
+/plugin marketplace add longbridge/skills
+/plugin install longbridge@longbridge-skills
+```
+
+此方式透過 Claude Code 插件系統安裝全部 Longbridge Skill，並可自動保持最新版本。
+
+**通過 npx / bunx（全局安裝）：**
 
 ```bash
 # Node.js
-npx skills add longbridge/developers -g -y
+npx skills add longbridge/skills -g
 # Bun
-bunx skills add longbridge/developers -g -y
+bunx skills add longbridge/skills -g
 ```
 
 > 需要 [Node.js](https://nodejs.org) 或 [Bun](https://bun.sh) 環境。


### PR DESCRIPTION
## Summary

- Fix npx/bunx install address: `longbridge/developers` → `longbridge/skills`（remove `-y` flag too）
- Add Claude Code plugin install as the first/recommended option for Claude Code users:
  ```
  /plugin marketplace add longbridge/skills
  /plugin install longbridge@longbridge-skills
  ```
- Change "Two ways" → "Three ways" in all three locales (en / zh-CN / zh-HK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)