### PR TITLE
docs(skill): restructure install guide — CLI/MCP first, add tool restrictions

### DIFF
--- a/docs/en/skill/install/index.md
+++ b/docs/en/skill/install/index.md
@@ -138,7 +138,7 @@ Some environments have network whitelists or sandboxing that block CLI installat
 
 ### Claude Desktop — use the Code tab
 
-**Chat mode** in Claude Desktop has network restrictions that prevent CLI installation and MCP server connections. Do not try to install from Chat mode — it will not work no matter how many times you retry.
+**Chat and Cowork modes** in Claude Desktop have network restrictions that prevent CLI installation and MCP server connections. Do not try to install from either of these modes — it will not work no matter how many times you retry.
 
 Switch to the **Code** tab in Claude Desktop (this is Claude Code embedded in the app). From the Code tab, you have full terminal access — you can install the CLI, connect MCP, and install the Skill all in one session.
 

--- a/docs/en/skill/install/index.md
+++ b/docs/en/skill/install/index.md
@@ -16,9 +16,86 @@ Once installed, you can say things like this to your AI assistant and get real a
 
 ---
 
-## Step 1 — Install the Skill
+The quickest way to get started is with a terminal-based AI tool — Claude Code, Codex, opencode, or OpenClaw. Install the CLI, authenticate once, and the AI runs `longbridge` commands on your behalf.
 
-The Skill is a set of instruction files that tell your AI assistant what Longbridge can do. Three ways to install:
+If you'd rather not install local software, connect via MCP instead — just add a URL to your AI tool's config.
+
+Either way, also install the Skill: a set of instruction files that tells your AI what Longbridge can do and how to use it.
+
+---
+
+## Step 1 — Connect to the Longbridge platform
+
+CLI and MCP are both ways to access the Longbridge Developers platform. Pick one:
+
+- **CLI** — best experience; the AI runs `longbridge` commands directly in your terminal; requires installing software on your system
+- **MCP** — easier to connect; just add a URL to your AI tool's config; no local install needed
+
+### Method A — CLI (recommended)
+
+Works with Claude Code, Codex (Work locally), opencode, OpenClaw, Gemini CLI, Warp, and any tool that can run shell commands.
+
+**Install the CLI:**
+
+```bash
+# macOS (requires Homebrew — install at https://brew.sh if not already installed)
+brew install --cask longbridge/tap/longbridge-terminal
+
+# macOS / Linux
+curl -sSL https://open.longbridge.com/longbridge/longbridge-terminal/install | sh
+```
+
+**Windows** ([Scoop](https://scoop.sh)):
+
+```powershell
+scoop install https://open.longbridge.com/longbridge/longbridge-terminal/longbridge.json
+```
+
+**Windows** (PowerShell):
+
+```powershell
+iwr https://open.longbridge.com/longbridge/longbridge-terminal/install.ps1 | iex
+```
+
+**Authenticate:**
+
+```bash
+longbridge auth login
+```
+
+That's it. The AI can now call `longbridge` commands on your behalf.
+
+> See the [CLI reference](/docs/cli) for the full command list and installation details.
+
+### Method B — MCP
+
+Works with Claude Desktop, Cursor, Zed, Gemini CLI, Warp, and any tool that supports MCP.
+
+Add the following as a remote MCP server in your AI tool:
+
+```
+https://openapi.longbridge.com/mcp
+```
+
+> Users in mainland China can use the accelerated endpoint: `https://openapi.longbridge.cn/mcp`
+
+Where to find the MCP configuration in each client:
+
+| Client         | Where to configure                                                                                                                        |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Desktop | Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows) |
+| Cursor         | Settings → MCP Servers → Add Remote MCP Server                                                                                            |
+| Zed            | `context_servers` key in `~/.config/zed/settings.json`                                                                                    |
+| Gemini CLI     | `mcpServers` key in `~/.gemini/settings.json`                                                                                             |
+| Warp           | Settings → AI → MCP Servers → Add                                                                                                         |
+
+The first time you ask a Longbridge question, your client will open a browser tab for OAuth authorization — no API key required.
+
+---
+
+## Step 2 — Install the Skill
+
+The Skill is a set of instruction files that tell your AI assistant what Longbridge can do.
 
 **Via Claude Code plugin (recommended for Claude Code users):**
 
@@ -55,78 +132,29 @@ https://open.longbridge.com/skill/longbridge-all.zip
 
 ---
 
-## Step 2 — Connect your Longbridge account
+## Known restrictions by tool
 
-The Skill tells the AI what's possible. To actually fetch live data or execute trades, you need one of two capabilities:
+Some environments have network whitelists or sandboxing that block CLI installation and MCP server connections. If things aren't working, check here first.
 
-- **Shell execution** — the AI runs `longbridge` commands directly in a terminal
-- **MCP integration** — the AI connects to the Longbridge MCP server over the network
+### Claude Desktop — use the Code tab
 
-### Method A — Install the CLI
+**Chat mode** in Claude Desktop has network restrictions that prevent CLI installation and MCP server connections. Do not try to install from Chat mode — it will not work no matter how many times you retry.
 
-For AI tools that can execute shell commands (Claude Code, Codex, Gemini CLI, Warp, etc.).
+Switch to the **Code** tab in Claude Desktop (this is Claude Code embedded in the app). From the Code tab, you have full terminal access — you can install the CLI, connect MCP, and install the Skill all in one session.
 
-**Install the CLI:**
+<img src="https://assets.lbctrl.com/uploads/76a34f28-9000-4e3e-8250-e992c516ce80/claude.png" alt="Claude Desktop — switch to the Code tab" />
 
-```bash
-# macOS (requires Homebrew — install at https://brew.sh if not already installed)
-brew install --cask longbridge/tap/longbridge-terminal
+### Codex — select "Work locally"
 
-# macOS / Linux
-curl -sSL https://open.longbridge.com/longbridge/longbridge-terminal/install | sh
-```
+Codex in **Cloud** mode has the same network whitelist restrictions. When starting a new session, select **Work locally** instead of Cloud. This gives the agent full access to your shell and network.
 
-**Windows** ([Scoop](https://scoop.sh)):
+<img src="https://assets.lbctrl.com/uploads/ccd412df-d312-45c3-a926-e3d466c9a479/codex.png" alt="Codex — select Work locally" />
 
-```powershell
-scoop install https://open.longbridge.com/longbridge/longbridge-terminal/longbridge.json
-```
+### Claude.ai and ChatGPT.com (web)
 
-**Windows** (PowerShell):
+Browser-based interfaces have no access to your local system. They cannot run shell commands or connect to external MCP servers.
 
-```powershell
-iwr https://open.longbridge.com/longbridge/longbridge-terminal/install.ps1 | iex
-```
-
-**Connect your Longbridge account:**
-
-```bash
-longbridge auth login
-```
-
-That's it. The AI can now call `longbridge` commands on your behalf.
-
-> See the [CLI reference](/docs/cli) for the full command list and installation details.
-
-### Method B — Connect the MCP server
-
-For AI tools that support MCP (Claude Desktop, Cursor, Zed, Gemini CLI, Warp, etc.).
-
-Add the following as a remote MCP server in your AI tool:
-
-```
-https://openapi.longbridge.com/mcp
-```
-
-Where to find the MCP configuration in each client:
-
-| Client         | Where to configure                                                                                                                        |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Claude Desktop | Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows) |
-| Cursor         | Settings → MCP Servers → Add Remote MCP Server                                                                                            |
-| Zed            | `context_servers` key in `~/.config/zed/settings.json`                                                                                    |
-| Gemini CLI     | `mcpServers` key in `~/.gemini/settings.json`                                                                                             |
-| Warp           | Settings → AI → MCP Servers → Add                                                                                                         |
-
-The first time you ask a Longbridge question, your client will open a browser tab for OAuth authorization — no API key required.
-
----
-
-## Why Claude.ai and ChatGPT.com don't work
-
-**Claude.ai** (web) and **ChatGPT.com** (web) are browser-based interfaces with no access to your local system. They cannot run shell commands or connect to external MCP servers, so the Skill has no way to fetch live market data or execute trades.
-
-If you use Claude, install [Claude Desktop](https://claude.ai/download) and use the MCP method above.
+For Claude, use [Claude Desktop](https://claude.ai/download) and switch to the **Code** tab.
 
 ---
 

--- a/docs/en/skill/install/index.md
+++ b/docs/en/skill/install/index.md
@@ -180,7 +180,7 @@ Some clients require a restart or a new conversation to load the Skill. Confirm 
 
 **Prompted for authorization when querying data**
 
-Run `longbridge auth login` in your terminal and complete the OAuth flow — no API Key required.
+Run `longbridge auth login` in your terminal and complete the OAuth flow.
 
 **Trading operations not working**
 

--- a/docs/zh-CN/skill/install/index.md
+++ b/docs/zh-CN/skill/install/index.md
@@ -87,7 +87,7 @@ https://openapi.longbridge.com/mcp
 | Gemini CLI     | `~/.gemini/settings.json` 中的 `mcpServers` 字段                                                                                           |
 | Warp           | Settings → AI → MCP Servers → Add                                                                                                          |
 
-首次提问时客户端会自动弹出浏览器完成 OAuth 授权，无需配置 API Key。
+首次提问时客户端会自动弹出浏览器完成 OAuth 授权。
 
 ---
 
@@ -178,7 +178,7 @@ Codex 的 **Cloud 模式**存在同样的网络白名单限制。启动新会话
 
 **查询数据时需要授权**
 
-在终端中运行 `longbridge auth login` 完成 OAuth 授权即可，无需配置 API Key。
+在终端中运行 `longbridge auth login` 完成 OAuth 授权即可。
 
 **交易操作无法执行**
 

--- a/docs/zh-CN/skill/install/index.md
+++ b/docs/zh-CN/skill/install/index.md
@@ -16,9 +16,84 @@ description: 在 OpenClaw、Claude Code、Cursor、Codex 等 AI 工具中安装 
 
 ---
 
-## 第一步：安装 Skill
+最快的上手方式是使用终端类 AI 工具——Claude Code、Codex、opencode 或 OpenClaw。安装好 CLI、完成一次授权，AI 就能直接代你运行 `longbridge` 命令。
 
-Skill 是一组指令文件，告诉 AI 助手 Longbridge 能做什么。安装方式有三种：
+如果不想在本地安装软件，也可以通过 MCP 接入——只需在 AI 工具的配置中填入一个 URL 即可。
+
+两种方式都建议同时安装 Skill：一组指令文件，告诉 AI 助手 Longbridge 能做什么、怎么用。
+
+---
+
+## 第一步：连接 Longbridge 平台
+
+CLI 和 MCP 都是接入 Longbridge Developers 平台的方式，两者均可，选其一即可：
+
+- **CLI**：体验最佳，AI 直接在终端运行 `longbridge` 命令；需要在系统上安装软件
+- **MCP**：接入更简便，只需在 AI 工具配置中填入一个 URL；无需本地安装
+
+### 方式 A：CLI（推荐）
+
+适用于 Claude Code、Codex（Work locally 模式）、opencode、OpenClaw、Gemini CLI、Warp 等可在终端执行命令的工具。
+
+```bash
+# macOS（需要 Homebrew，未安装请先访问 https://brew.sh）
+brew install --cask longbridge/tap/longbridge-terminal
+
+# macOS / Linux
+curl -sSL https://open.longbridge.com/longbridge/longbridge-terminal/install | sh
+```
+
+**Windows**（[Scoop](https://scoop.sh)）：
+
+```powershell
+scoop install https://open.longbridge.com/longbridge/longbridge-terminal/longbridge.json
+```
+
+**Windows**（PowerShell）：
+
+```powershell
+iwr https://open.longbridge.com/longbridge/longbridge-terminal/install.ps1 | iex
+```
+
+**授权登录：**
+
+```bash
+longbridge auth login
+```
+
+完成后，AI 即可代你调用 `longbridge` 命令。
+
+> 详细安装说明及完整命令列表参见 [CLI 文档](/zh-CN/docs/cli)。
+
+### 方式 B：MCP
+
+适用于 Claude Desktop、Cursor、Zed、Gemini CLI、Warp 等支持 MCP 的工具。
+
+在 AI 工具的 MCP 配置中添加以下服务器地址：
+
+```
+https://openapi.longbridge.com/mcp
+```
+
+> 中国大陆用户可使用加速地址：`https://openapi.longbridge.cn/mcp`
+
+各工具配置入口：
+
+| 工具           | 配置位置                                                                                                                                   |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Claude Desktop | 编辑 `~/Library/Application Support/Claude/claude_desktop_config.json`（macOS）或 `%APPDATA%\Claude\claude_desktop_config.json`（Windows） |
+| Cursor         | Settings → MCP Servers → Add Remote MCP Server                                                                                             |
+| Zed            | `~/.config/zed/settings.json` 中的 `context_servers` 字段                                                                                  |
+| Gemini CLI     | `~/.gemini/settings.json` 中的 `mcpServers` 字段                                                                                           |
+| Warp           | Settings → AI → MCP Servers → Add                                                                                                          |
+
+首次提问时客户端会自动弹出浏览器完成 OAuth 授权，无需配置 API Key。
+
+---
+
+## 第二步：安装 Skill
+
+Skill 是一组指令文件，告诉 AI 助手 Longbridge 能做什么。
 
 **通过 Claude Code 插件安装（Claude Code 用户推荐）：**
 
@@ -55,71 +130,29 @@ https://open.longbridge.com/skill/longbridge-all.zip
 
 ---
 
-## 第二步：连接 Longbridge 账户
+## 各工具的已知限制
 
-Skill 只是让 AI 知道能做什么，要真正获取行情数据或执行交易，还需要连接 Longbridge 账户。根据你的 AI 工具选择接入方式：
+部分环境存在网络白名单或沙箱限制，会阻止 CLI 安装和 MCP 服务器连接。遇到问题请先查阅本节。
 
-### 方式 A：安装 CLI（适用于有 shell 执行能力的工具）
+### Claude Desktop — 切换到 Code 标签页
 
-Claude Code、Codex、Gemini CLI、Warp 等可以直接在终端执行命令的工具适用此方式。
+Claude Desktop 的 **Chat 模式**存在网络限制，无法安装 CLI 或连接 MCP 服务器。不要在 Chat 模式下反复尝试，这样不会成功。
 
-```bash
-# macOS（需要 Homebrew，未安装请先访问 https://brew.sh）
-brew install --cask longbridge/tap/longbridge-terminal
+切换到 Claude Desktop 的 **Code 标签页**（即 App 内嵌的 Claude Code）。在 Code 标签页下，你拥有完整的终端访问权限，可以在同一个会话中完成 CLI 安装、MCP 连接和 Skill 安装。
 
-# macOS / Linux
-curl -sSL https://open.longbridge.com/longbridge/longbridge-terminal/install | sh
-```
+<img src="https://assets.lbctrl.com/uploads/76a34f28-9000-4e3e-8250-e992c516ce80/claude.png" alt="Claude Desktop — 切换到 Code 标签页" />
 
-**Windows**（[Scoop](https://scoop.sh)）：
+### Codex — 选择「Work locally」
 
-```powershell
-scoop install https://open.longbridge.com/longbridge/longbridge-terminal/longbridge.json
-```
+Codex 的 **Cloud 模式**存在同样的网络白名单限制。启动新会话时，请选择 **Work locally** 而非 Cloud。本地模式下 AI 可完整访问你的 shell 和网络。
 
-**Windows**（PowerShell）：
+<img src="https://assets.lbctrl.com/uploads/ccd412df-d312-45c3-a926-e3d466c9a479/codex.png" alt="Codex — 选择 Work locally" />
 
-```powershell
-iwr https://open.longbridge.com/longbridge/longbridge-terminal/install.ps1 | iex
-```
+### Claude.ai 和 ChatGPT.com（网页版）
 
-```bash
-longbridge auth login
-```
+基于浏览器的界面无法访问本地系统，既不能执行 shell 命令，也无法连接外部 MCP 服务器。
 
-> 详细安装说明及完整命令列表参见 [CLI 文档](/zh-CN/docs/cli)。
-
-### 方式 B：连接 MCP 服务器（适用于支持 MCP 的工具）
-
-Claude Desktop、Cursor、Zed、Gemini CLI、Warp 等支持 MCP 的工具适用此方式。
-
-在 AI 工具的 MCP 配置中添加以下服务器地址：
-
-```
-https://openapi.longbridge.com/mcp
-```
-
-> 中国大陆用户可使用加速地址：`https://openapi.longbridge.cn/mcp`
-
-各工具配置入口：
-
-| 工具           | 配置位置                                                                                                                                   |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Claude Desktop | 编辑 `~/Library/Application Support/Claude/claude_desktop_config.json`（macOS）或 `%APPDATA%\Claude\claude_desktop_config.json`（Windows） |
-| Cursor         | Settings → MCP Servers → Add Remote MCP Server                                                                                             |
-| Zed            | `~/.config/zed/settings.json` 中的 `context_servers` 字段                                                                                  |
-| Gemini CLI     | `~/.gemini/settings.json` 中的 `mcpServers` 字段                                                                                           |
-| Warp           | Settings → AI → MCP Servers → Add                                                                                                          |
-
-首次提问时客户端会自动弹出浏览器完成 OAuth 授权，无需配置 API Key。
-
----
-
-## 为什么 Claude.ai 和 ChatGPT.com 无法使用
-
-**Claude.ai**（网页版）和 **ChatGPT.com**（网页版）是基于浏览器的界面，无法访问你的本地系统，既不能执行 shell 命令，也无法连接外部 MCP 服务器，因此 Skill 无法获取实时行情或执行交易。
-
-如果你使用 Claude，请安装 [Claude Desktop](https://claude.ai/download) 并通过上方的 MCP 方式接入。
+如果你使用 Claude，请安装 [Claude Desktop](https://claude.ai/download) 并切换到 **Code 标签页**。
 
 ---
 

--- a/docs/zh-CN/skill/install/index.md
+++ b/docs/zh-CN/skill/install/index.md
@@ -136,7 +136,7 @@ https://open.longbridge.com/skill/longbridge-all.zip
 
 ### Claude Desktop — 切换到 Code 标签页
 
-Claude Desktop 的 **Chat 模式**存在网络限制，无法安装 CLI 或连接 MCP 服务器。不要在 Chat 模式下反复尝试，这样不会成功。
+Claude Desktop 的 **Chat 和 Cowork 模式**都存在网络限制，无法安装 CLI 或连接 MCP 服务器。不要在这两种模式下反复尝试，这样不会成功。
 
 切换到 Claude Desktop 的 **Code 标签页**（即 App 内嵌的 Claude Code）。在 Code 标签页下，你拥有完整的终端访问权限，可以在同一个会话中完成 CLI 安装、MCP 连接和 Skill 安装。
 

--- a/docs/zh-HK/skill/install/index.md
+++ b/docs/zh-HK/skill/install/index.md
@@ -16,9 +16,84 @@ description: 在 OpenClaw、Claude Code、Cursor、Codex 等 AI 工具中安裝 
 
 ---
 
-## 第一步：安裝 Skill
+最快的上手方式是使用終端類 AI 工具——Claude Code、Codex、opencode 或 OpenClaw。安裝好 CLI、完成一次授權，AI 就能直接代你執行 `longbridge` 命令。
 
-Skill 是一組指令文件，告訴 AI 助手 Longbridge 能做什麼。安裝方式有三種：
+如果不想在本機安裝軟件，也可以透過 MCP 接入——只需在 AI 工具的配置中填入一個 URL 即可。
+
+兩種方式都建議同時安裝 Skill：一組指令文件，告訴 AI 助手 Longbridge 能做什麼、怎麼用。
+
+---
+
+## 第一步：連接 Longbridge 平台
+
+CLI 和 MCP 都是接入 Longbridge Developers 平台的方式，兩者均可，選其一即可：
+
+- **CLI**：體驗最佳，AI 直接在終端執行 `longbridge` 命令；需要在系統上安裝軟件
+- **MCP**：接入更簡便，只需在 AI 工具配置中填入一個 URL；無需本地安裝
+
+### 方式 A：CLI（推薦）
+
+適用於 Claude Code、Codex（Work locally 模式）、opencode、OpenClaw、Gemini CLI、Warp 等可在終端執行命令的工具。
+
+```bash
+# macOS（需要 Homebrew，未安裝請先訪問 https://brew.sh）
+brew install --cask longbridge/tap/longbridge-terminal
+
+# macOS / Linux
+curl -sSL https://open.longbridge.com/longbridge/longbridge-terminal/install | sh
+```
+
+**Windows**（[Scoop](https://scoop.sh)）：
+
+```powershell
+scoop install https://open.longbridge.com/longbridge/longbridge-terminal/longbridge.json
+```
+
+**Windows**（PowerShell）：
+
+```powershell
+iwr https://open.longbridge.com/longbridge/longbridge-terminal/install.ps1 | iex
+```
+
+**授權登入：**
+
+```bash
+longbridge auth login
+```
+
+完成後，AI 即可代你調用 `longbridge` 命令。
+
+> 詳細安裝說明及完整指令列表參見 [CLI 文檔](/zh-HK/docs/cli)。
+
+### 方式 B：MCP
+
+適用於 Claude Desktop、Cursor、Zed、Gemini CLI、Warp 等支援 MCP 的工具。
+
+在 AI 工具的 MCP 配置中新增以下伺服器地址：
+
+```
+https://openapi.longbridge.com/mcp
+```
+
+> 中國大陸用戶可使用加速地址：`https://openapi.longbridge.cn/mcp`
+
+各工具配置入口：
+
+| 工具           | 配置位置                                                                                                                                   |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Claude Desktop | 編輯 `~/Library/Application Support/Claude/claude_desktop_config.json`（macOS）或 `%APPDATA%\Claude\claude_desktop_config.json`（Windows） |
+| Cursor         | Settings → MCP Servers → Add Remote MCP Server                                                                                             |
+| Zed            | `~/.config/zed/settings.json` 中的 `context_servers` 字段                                                                                  |
+| Gemini CLI     | `~/.gemini/settings.json` 中的 `mcpServers` 字段                                                                                           |
+| Warp           | Settings → AI → MCP Servers → Add                                                                                                          |
+
+首次提問時客戶端會自動彈出瀏覽器完成 OAuth 授權，無需配置 API Key。
+
+---
+
+## 第二步：安裝 Skill
+
+Skill 是一組指令文件，告訴 AI 助手 Longbridge 能做什麼。
 
 **通過 Claude Code 插件安裝（Claude Code 用戶推薦）：**
 
@@ -31,7 +106,7 @@ Skill 是一組指令文件，告訴 AI 助手 Longbridge 能做什麼。安裝�
 
 此方式透過 Claude Code 插件系統安裝全部 Longbridge Skill，並可自動保持最新版本。
 
-**通過 npx / bunx（全局安裝）：**
+**通過 npx / bunx（全域安裝）：**
 
 ```bash
 # Node.js
@@ -55,71 +130,29 @@ https://open.longbridge.com/skill/longbridge-all.zip
 
 ---
 
-## 第二步：連接 Longbridge 帳戶
+## 各工具的已知限制
 
-Skill 只是讓 AI 知道能做什麼，要真正獲取行情數據或執行交易，還需要連接 Longbridge 帳戶。根據你的 AI 工具選擇接入方式：
+部分環境存在網絡白名單或沙箱限制，會阻止 CLI 安裝和 MCP 伺服器連接。遇到問題請先查閱本節。
 
-### 方式 A：安裝 CLI（適用於有 shell 執行能力的工具）
+### Claude Desktop — 切換到 Code 標籤頁
 
-Claude Code、Codex、Gemini CLI、Warp 等可以直接在終端執行命令的工具適用此方式。
+Claude Desktop 的 **Chat 模式**存在網絡限制，無法安裝 CLI 或連接 MCP 伺服器。不要在 Chat 模式下反覆嘗試，這樣不會成功。
 
-```bash
-# macOS（需要 Homebrew，未安裝請先訪問 https://brew.sh）
-brew install --cask longbridge/tap/longbridge-terminal
+切換到 Claude Desktop 的 **Code 標籤頁**（即 App 內嵌的 Claude Code）。在 Code 標籤頁下，你擁有完整的終端存取權限，可以在同一個會話中完成 CLI 安裝、MCP 連接和 Skill 安裝。
 
-# macOS / Linux
-curl -sSL https://open.longbridge.com/longbridge/longbridge-terminal/install | sh
-```
+<img src="https://assets.lbctrl.com/uploads/76a34f28-9000-4e3e-8250-e992c516ce80/claude.png" alt="Claude Desktop — 切換到 Code 標籤頁" />
 
-**Windows**（[Scoop](https://scoop.sh)）：
+### Codex — 選擇「Work locally」
 
-```powershell
-scoop install https://open.longbridge.com/longbridge/longbridge-terminal/longbridge.json
-```
+Codex 的 **Cloud 模式**存在同樣的網絡白名單限制。啟動新會話時，請選擇 **Work locally** 而非 Cloud。本地模式下 AI 可完整存取你的 shell 和網絡。
 
-**Windows**（PowerShell）：
+<img src="https://assets.lbctrl.com/uploads/ccd412df-d312-45c3-a926-e3d466c9a479/codex.png" alt="Codex — 選擇 Work locally" />
 
-```powershell
-iwr https://open.longbridge.com/longbridge/longbridge-terminal/install.ps1 | iex
-```
+### Claude.ai 和 ChatGPT.com（網頁版）
 
-```bash
-longbridge auth login
-```
+基於瀏覽器的界面無法存取本地系統，既不能執行 shell 命令，也無法連接外部 MCP 伺服器。
 
-> 詳細安裝說明及完整指令列表參見 [CLI 文檔](/zh-HK/docs/cli)。
-
-### 方式 B：連接 MCP 伺服器（適用於支持 MCP 的工具）
-
-Claude Desktop、Cursor、Zed、Gemini CLI、Warp 等支持 MCP 的工具適用此方式。
-
-在 AI 工具的 MCP 配置中添加以下伺服器地址：
-
-```
-https://openapi.longbridge.com/mcp
-```
-
-> 中國大陸用戶可使用加速地址：`https://openapi.longbridge.cn/mcp`
-
-各工具配置入口：
-
-| 工具           | 配置位置                                                                                                                                   |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Claude Desktop | 編輯 `~/Library/Application Support/Claude/claude_desktop_config.json`（macOS）或 `%APPDATA%\Claude\claude_desktop_config.json`（Windows） |
-| Cursor         | Settings → MCP Servers → Add Remote MCP Server                                                                                             |
-| Zed            | `~/.config/zed/settings.json` 中的 `context_servers` 字段                                                                                  |
-| Gemini CLI     | `~/.gemini/settings.json` 中的 `mcpServers` 字段                                                                                           |
-| Warp           | Settings → AI → MCP Servers → Add                                                                                                          |
-
-首次提問時客戶端會自動彈出瀏覽器完成 OAuth 授權，無需配置 API Key。
-
----
-
-## 為什麼 Claude.ai 和 ChatGPT.com 無法使用
-
-**Claude.ai**（網頁版）和 **ChatGPT.com**（網頁版）是基於瀏覽器的界面，無法訪問你的本地系統，既不能執行 shell 命令，也無法連接外部 MCP 伺服器，因此 Skill 無法獲取實時行情或執行交易。
-
-如果你使用 Claude，請安裝 [Claude Desktop](https://claude.ai/download) 並通過上方的 MCP 方式接入。
+如果你使用 Claude，請安裝 [Claude Desktop](https://claude.ai/download) 並切換到 **Code 標籤頁**。
 
 ---
 

--- a/docs/zh-HK/skill/install/index.md
+++ b/docs/zh-HK/skill/install/index.md
@@ -136,7 +136,7 @@ https://open.longbridge.com/skill/longbridge-all.zip
 
 ### Claude Desktop — 切換到 Code 標籤頁
 
-Claude Desktop 的 **Chat 模式**存在網絡限制，無法安裝 CLI 或連接 MCP 伺服器。不要在 Chat 模式下反覆嘗試，這樣不會成功。
+Claude Desktop 的 **Chat 和 Cowork 模式**都存在網絡限制，無法安裝 CLI 或連接 MCP 伺服器。不要在這兩種模式下反覆嘗試，這樣不會成功。
 
 切換到 Claude Desktop 的 **Code 標籤頁**（即 App 內嵌的 Claude Code）。在 Code 標籤頁下，你擁有完整的終端存取權限，可以在同一個會話中完成 CLI 安裝、MCP 連接和 Skill 安裝。
 

--- a/docs/zh-HK/skill/install/index.md
+++ b/docs/zh-HK/skill/install/index.md
@@ -178,7 +178,7 @@ Codex 的 **Cloud 模式**存在同樣的網絡白名單限制。啟動新會話
 
 **查詢數據時需要授權**
 
-在終端中運行 `longbridge auth login` 完成 OAuth 授權即可，無需配置 API Key。
+在終端中運行 `longbridge auth login` 完成 OAuth 授權即可。
 
 **交易操作無法執行**
 


### PR DESCRIPTION
## Summary

- Reorder steps: connect to Longbridge platform (CLI or MCP) first, install Skill second — the old order had Skill as Step 1, which is useless without data access
- Lead intro with terminal-based AI tools (Claude Code, Codex, opencode, OpenClaw) as the recommended/quickest path
- Clarify CLI vs MCP framing: CLI = best experience but needs local install; MCP = easier, just a URL
- Add **Known restrictions by tool** section with clear guidance and screenshots:
  - **Claude Desktop Chat mode**: network whitelist blocks CLI/MCP — switch to Code tab instead (screenshot added)
  - **Codex Cloud mode**: same network restrictions — must select "Work locally" (screenshot added)
  - **Claude.ai / ChatGPT.com web**: redirect to Claude Desktop Code tab
- Add mainland China accelerated MCP endpoint (`https://openapi.longbridge.cn/mcp`) to English version
- Rename section heading "Connect your Longbridge account" → "Connect to the Longbridge platform"
- All changes synced across en / zh-CN / zh-HK

## Test plan

- [ ] Preview skill install page in all three locales
- [ ] Verify screenshots render correctly
- [ ] Check all links resolve (CLI reference, Claude Desktop download)

🤖 Generated with [Claude Code](https://claude.com/claude-code)