### PR TITLE
docs: CLI v0.20.2 release notes + Pricing US quote session clarification

### DIFF
--- a/docs/.vitepress/theme/components/Pricing.vue
+++ b/docs/.vitepress/theme/components/Pricing.vue
@@ -73,12 +73,12 @@ const t = computed(() => {
     freeItems: zh
       ? [
           { name: '交易 & 账户 API', note: '个股基本面、分析、资讯、资产、订单等基础 API 功能免费' },
-          { name: '基础行情', note: 'Nasdaq Basic、港股 LV1、沪深 LV1' },
+          { name: '基础行情', note: 'Nasdaq Basic（含盘前、盘中、盘后）、港股 LV1、沪深 LV1' },
           { name: '数据推送 & 拉取', note: 'WebSocket 实时推送、REST API 主动拉取，无限制' },
         ]
       : [
           { name: 'Trading & Account APIs', note: 'Fundamentals, analysis, news, assets, orders — core APIs free' },
-          { name: 'Basic Market Data', note: 'Nasdaq Basic, HK LV1, CN LV1' },
+          { name: 'Basic Market Data', note: 'Nasdaq Basic (pre-market, regular & after-hours), HK LV1, CN LV1' },
           { name: 'Push & Pull Data', note: 'WebSocket real-time push and REST API pull — unlimited' },
         ],
 
@@ -157,7 +157,8 @@ const t = computed(() => {
           { feature: 'WebSocket 实时行情推送', values: [true, true, true, true, true, true] },
           { feature: 'Pull 主动拉取行情', values: [true, true, true, true, true, true] },
           { feature: '美股实时行情（买卖一档）', values: [true, true, false, false, false, false] },
-          { feature: '盘前盘后（夜盘）行情', values: [false, true, false, false, false, false] },
+          { feature: '盘前、盘中、盘后行情', values: [true, true, false, false, false, false] },
+          { feature: '夜盘行情', values: [false, true, false, false, false, false] },
           { feature: '期权链 & 实时报价', values: [false, false, true, false, false, false] },
           { feature: '港股实时行情（基础）', values: [false, false, false, true, true, false] },
           { feature: '恒生指数行情', values: [false, false, false, true, true, false] },
@@ -171,7 +172,8 @@ const t = computed(() => {
           { feature: 'WebSocket Real-time Quote Push', values: [true, true, true, true, true, true] },
           { feature: 'Pull Quote (REST API)', values: [true, true, true, true, true, true] },
           { feature: 'US Quotes (Best Bid/Ask)', values: [true, true, false, false, false, false] },
-          { feature: 'Pre/post-market (overnight)', values: [false, true, false, false, false, false] },
+          { feature: 'Pre-market, regular & after-hours', values: [true, true, false, false, false, false] },
+          { feature: 'Overnight (night session)', values: [false, true, false, false, false, false] },
           { feature: 'Options Chain & Real-time Quotes', values: [false, false, true, false, false, false] },
           { feature: 'HK Real-time (basic)', values: [false, false, false, true, true, false] },
           { feature: 'Hang Seng Index', values: [false, false, false, true, true, false] },

--- a/docs/en/docs/cli/release-notes.md
+++ b/docs/en/docs/cli/release-notes.md
@@ -7,6 +7,11 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.20.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.20.2)
+
+- **Fix: `institution-rating --history`** — restructured as a proper table with logical column ordering; timestamps formatted as `YYYY-MM-DD`; price targets rounded to 2 decimal places; `evaluate_history` capped to 20 most recent records
+- **Fix: IPO date display** — `ipo listed`, `ipo wait-listing`, `ipo calendar`, `ipo us-wait-listing` now show correct dates (e.g. `2026-05-11`) instead of a bogus 1970 date
+
 ### [v0.20.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.20.0)
 
 - **`ipo` command group** — comprehensive IPO tools: `subscriptions`, `wait-listing`, `listed`, `calendar`, `detail`, `orders`, `profit-loss` for HK market; `us-subscriptions`, `us-wait-listing`, `us-listed` for US market; `orders detail <id>` for full order detail

--- a/docs/zh-CN/docs/cli/release-notes.md
+++ b/docs/zh-CN/docs/cli/release-notes.md
@@ -7,6 +7,11 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.20.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.20.2)
+
+- **修复：`institution-rating --history` 输出格式** — 改为表格布局，列顺序更合理；时间戳格式化为 `YYYY-MM-DD`；目标价保留 2 位小数；`evaluate_history` 仅展示最近 20 条记录
+- **修复：IPO 日期显示** — `ipo listed`、`ipo wait-listing`、`ipo calendar`、`ipo us-wait-listing` 现在正确显示日期（如 `2026-05-11`），不再出现 1970 年的错误日期
+
 ### [v0.20.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.20.0)
 
 - **`ipo` 命令组** — 完整 IPO 工具：港股支持 `subscriptions`（在招）、`wait-listing`（暗盘）、`listed`（近期上市）、`calendar`（日历）、`detail`（详情）、`orders`（订单）、`profit-loss`（盈亏）；美股支持 `us-subscriptions`、`us-wait-listing`、`us-listed`

--- a/docs/zh-HK/docs/cli/release-notes.md
+++ b/docs/zh-HK/docs/cli/release-notes.md
@@ -7,6 +7,11 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.20.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.20.2)
+
+- **修復：`institution-rating --history` 輸出格式** — 改為表格版面，欄位順序更合理；時間戳格式化為 `YYYY-MM-DD`；目標價保留 2 位小數；`evaluate_history` 僅顯示最近 20 條記錄
+- **修復：IPO 日期顯示** — `ipo listed`、`ipo wait-listing`、`ipo calendar`、`ipo us-wait-listing` 現在正確顯示日期（如 `2026-05-11`），不再出現 1970 年的錯誤日期
+
 ### [v0.20.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.20.0)
 
 - **`ipo` 指令組** — 完整 IPO 工具：港股支持 `subscriptions`（招股中）、`wait-listing`（暗盤）、`listed`（近期上市）、`calendar`（日曆）、`detail`（詳情）、`orders`（訂單）、`profit-loss`（盈虧）；美股支持 `us-subscriptions`、`us-wait-listing`、`us-listed`

--- a/quote-permissions.yaml
+++ b/quote-permissions.yaml
@@ -86,15 +86,15 @@ commands:
     level: lv1
     description:
       en: |-
-        US stocks: Nasdaq Basic 1-level bid/ask included by default; overnight requires LV1.
+        US stocks: Nasdaq Basic 1-level bid/ask included by default (pre-market, regular, and after-hours sessions); overnight requires LV1.
         HK stocks: LV1 1-level bid/ask included by default; 10-level order book requires "LV2 Advanced Quotes - Plus (OpenAPI)".
         US options: no permission by default — purchase "OPRA US Options Quotes (OpenAPI)".
       zh-CN: |-
-        美股：默认赠送 Nasdaq Basic 一档买卖盘报价；夜盘报价需购买 LV1。
+        美股：默认赠送 Nasdaq Basic 一档买卖盘报价（含盘前、盘中、盘后时段）；夜盘报价需购买 LV1。
         港股：默认赠送 LV1 一档买卖盘报价；十档买卖盘需购买「LV2 高级行情 - Plus (OpenAPI)」行情卡。
         美股期权：默认无权限，需购买「OPRA 美股期权行情 (OpenAPI)」行情卡。
       zh-HK: |-
-        美股：預設贈送 Nasdaq Basic 一檔買賣盤報價；夜盤報價需購買 LV1。
+        美股：預設贈送 Nasdaq Basic 一檔買賣盤報價（含盤前、盤中、盤後時段）；夜盤報價需購買 LV1。
         港股：預設贈送 LV1 一檔買賣盤報價；十檔買賣盤需購買「LV2 高級行情 - Plus (OpenAPI)」行情卡。
         美股期權：預設無權限，需購買「OPRA 美股期權行情 (OpenAPI)」行情卡。
     store_cards:
@@ -179,17 +179,17 @@ commands:
     description:
       en: |-
         Quota-based access: 100–3,000 unique symbols per calendar month depending on account tier (resets monthly; see quota table in the docs).
-        US stocks: Nasdaq Basic included by default; overnight requires LV1.
+        US stocks: Nasdaq Basic included by default (pre-market, regular, and after-hours sessions); overnight requires LV1.
         HK stocks: LV1 included by default.
         US options: no permission by default — purchase "OPRA US Options Quotes (OpenAPI)".
       zh-CN: |-
         按账户等级配额，每自然月可查询 100–3,000 个标的（每月重置，详见文档中的配额表）。
-        美股：默认赠送 Nasdaq Basic 行情；夜盘需购买 LV1。
+        美股：默认赠送 Nasdaq Basic 行情（含盘前、盘中、盘后时段）；夜盘需购买 LV1。
         港股：默认赠送 LV1 行情。
         美股期权：默认无权限，需购买「OPRA 美股期权行情 (OpenAPI)」行情卡。
       zh-HK: |-
         按帳戶等級配額，每自然月可查詢 100–3,000 個標的（每月重置，詳見文檔中的配額表）。
-        美股：預設贈送 Nasdaq Basic 行情；夜盤需購買 LV1。
+        美股：預設贈送 Nasdaq Basic 行情（含盤前、盤中、盤後時段）；夜盤需購買 LV1。
         港股：預設贈送 LV1 行情。
         美股期權：預設無權限，需購買「OPRA 美股期權行情 (OpenAPI)」行情卡。
     store_cards:


### PR DESCRIPTION
## Summary

- Add CLI v0.20.2 release notes (EN / zh-CN / zh-HK): two bug fixes — `institution-rating --history` output formatting and IPO date display (1970 → correct date)
- Pricing comparison table: split the misleading "盘前盘后（夜盘）行情" row into two distinct rows — "盘前、盘中、盘后行情" (✓ Nasdaq Basic free) and "夜盘行情" (✓ US LV1 paid only)
- Free tier card note updated to mention Nasdaq Basic covers pre-market, regular & after-hours sessions
- `quote-permissions.yaml`: add session coverage detail to `depth` and `kline` command descriptions, consistent with `quote` / `trades` / `intraday`

## Test plan

- [ ] Verify Pricing page comparison table shows correct checkmarks for the two new rows
- [ ] Verify release notes appear correctly in all three locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)