### PR TITLE
docs(skill): add JSON config example for MCP server setup

### DIFF
--- a/docs/en/skill/install/index.md
+++ b/docs/en/skill/install/index.md
@@ -85,6 +85,18 @@ Add the following as a remote MCP server in your AI tool:
 https://openapi.longbridge.com/mcp
 ```
 
+For clients that use a JSON config file (Claude Desktop, Cursor, Zed, Gemini CLI, etc.), add this to your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "longbridge": {
+      "url": "https://openapi.longbridge.com/mcp"
+    }
+  }
+}
+```
+
 > Users in mainland China can use the accelerated endpoint: `https://openapi.longbridge.cn/mcp`
 
 Where to find the MCP configuration in each client:

--- a/docs/zh-CN/skill/install/index.md
+++ b/docs/zh-CN/skill/install/index.md
@@ -83,6 +83,18 @@ longbridge auth login
 https://openapi.longbridge.com/mcp
 ```
 
+对于使用 JSON 配置文件的客户端（Claude Desktop、Cursor、Zed、Gemini CLI 等），将以下内容添加到 MCP 配置中：
+
+```json
+{
+  "mcpServers": {
+    "longbridge": {
+      "url": "https://openapi.longbridge.com/mcp"
+    }
+  }
+}
+```
+
 > 中国大陆用户可使用加速地址：`https://openapi.longbridge.cn/mcp`
 
 各工具配置入口：

--- a/docs/zh-HK/skill/install/index.md
+++ b/docs/zh-HK/skill/install/index.md
@@ -83,6 +83,18 @@ longbridge auth login
 https://openapi.longbridge.com/mcp
 ```
 
+對於使用 JSON 配置文件的客戶端（Claude Desktop、Cursor、Zed、Gemini CLI 等），將以下內容添加到 MCP 配置中：
+
+```json
+{
+  "mcpServers": {
+    "longbridge": {
+      "url": "https://openapi.longbridge.com/mcp"
+    }
+  }
+}
+```
+
 > 中國大陸用戶可使用加速地址：`https://openapi.longbridge.cn/mcp`
 
 各工具配置入口：


### PR DESCRIPTION
## Summary

- Add JSON `mcpServers` config block to Method B (MCP) section of the Skill install guide
- Clarifies that the JSON format works for Claude Desktop, Cursor, Zed, Gemini CLI, and other JSON-config-based clients
- Updated all three language versions (en, zh-CN, zh-HK)

## Test plan

- [ ] Verify the JSON block renders correctly in the docs
- [ ] Check all three language versions display properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)