### PR TITLE
ci: add pack-skills workflow triggered by repository_dispatch

### DIFF
--- a/.github/workflows/pack-skills.yml
+++ b/.github/workflows/pack-skills.yml
@@ -1,0 +1,80 @@
+name: Pack and upload skills
+
+on:
+  repository_dispatch:
+    types:
+      - skill-updated
+  workflow_dispatch: # manual trigger for testing
+
+concurrency:
+  group: pack-skills
+  cancel-in-progress: true
+
+jobs:
+  pack-and-upload:
+    name: Pack skills and upload to OSS
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Install ossutil
+        run: |
+          wget -q https://github.com/aliyun/ossutil/releases/download/v1.7.17/ossutil-v1.7.17-linux-amd64.zip
+          unzip -q ossutil-v1.7.17-linux-amd64.zip
+          cp ./ossutil-v1.7.17-linux-amd64/ossutil ${{ github.workspace }}/ossutil
+          chmod +x ${{ github.workspace }}/ossutil
+          ${{ github.workspace }}/ossutil --version
+
+      - name: Clone longbridge/skills@main
+        run: |
+          git clone --depth 1 --branch main https://github.com/longbridge/skills.git skills-repo
+          echo "Cloned commit: $(git -C skills-repo rev-parse HEAD)"
+
+      - name: Pack skill zips
+        run: |
+          mkdir -p dist/skill
+          cd skills-repo/skills
+
+          # All skills in one zip
+          zip -r ${{ github.workspace }}/dist/skill/longbridge-all.zip .
+          echo "✓ longbridge-all.zip"
+
+          # One zip per skill directory
+          for dir in */; do
+            name="${dir%/}"
+            zip -r ${{ github.workspace }}/dist/skill/${name}.zip "$name"
+            echo "✓ ${name}.zip"
+          done
+
+          echo "Total zips: $(ls ${{ github.workspace }}/dist/skill/*.zip | wc -l)"
+
+      - name: Upload to OSS (canary)
+        run: |
+          ${{ github.workspace }}/ossutil cp dist/skill/ \
+            oss://lb-assets/github/canary/open.longbridge.com/new-docs/raw/skill/ \
+            -u -r -j 10 \
+            -e oss-cn-hangzhou.aliyuncs.com \
+            -i ${{ secrets.FE_LB_ASSET_ACCESS_KEY_ID }} \
+            -k ${{ secrets.FE_LB_ASSET_ACCESS_KEY_SECRET }} \
+            --include "*.zip" \
+            --meta "Cache-Control:no-cache#Content-type:application/zip;charset=utf-8"
+          echo "✓ Uploaded to canary OSS"
+
+      - name: Upload to OSS (release)
+        run: |
+          ${{ github.workspace }}/ossutil cp dist/skill/ \
+            oss://lb-assets/github/release/open.longbridge.com/new-docs/raw/skill/ \
+            -u -r -j 10 \
+            -e oss-cn-hangzhou.aliyuncs.com \
+            -i ${{ secrets.FE_LB_ASSET_ACCESS_KEY_ID }} \
+            -k ${{ secrets.FE_LB_ASSET_ACCESS_KEY_SECRET }} \
+            --include "*.zip" \
+            --meta "Cache-Control:no-cache#Content-type:application/zip;charset=utf-8"
+          echo "✓ Uploaded to release OSS"
+
+      - name: Summary
+        run: |
+          echo "### Skill upload complete" >> $GITHUB_STEP_SUMMARY
+          echo "- Triggered by: ${{ github.event.client_payload.ref || 'manual' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Skills SHA: ${{ github.event.client_payload.sha || 'manual' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Zips uploaded: $(ls dist/skill/*.zip | wc -l)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Adds a standalone workflow that listens for `skill-updated` dispatch events from `longbridge/skills` and runs **only** the skill pack + OSS upload — without triggering a full site build.

## What it does

1. Clones `longbridge/skills@main`
2. Packs each skill directory into a `.zip` + `longbridge-all.zip`
3. Uploads `skill/*.zip` to **both** OSS paths:
   - `oss://lb-assets/github/canary/.../skill/`
   - `oss://lb-assets/github/release/.../skill/`

## Trigger

- `repository_dispatch` with `event-type: skill-updated` (from `longbridge/skills` on push to main)
- `workflow_dispatch` for manual testing

## Secrets used

Reuses existing secrets — no new secrets needed:
- `FE_LB_ASSET_ACCESS_KEY_ID`
- `FE_LB_ASSET_ACCESS_KEY_SECRET`

## Counterpart

PR #23 in `longbridge/skills` sends the dispatch event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)