### PR TITLE
docs(cli): CLI v0.20.3 release notes + v0.20.0 changelog backfill

### DIFF
--- a/docs/en/docs/changelog.md
+++ b/docs/en/docs/changelog.md
@@ -6,6 +6,18 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-05-08
+
+### CLI v0.20.0
+
+- **`ipo` command group** — comprehensive IPO tools for HK (`subscriptions`, `wait-listing`, `listed`, `calendar`, `detail`, `orders`, `profit-loss`) and US markets (`us-subscriptions`, `us-wait-listing`, `us-listed`)
+- **`financial-statement`** — detailed hierarchical financial statements (IS/BS/CF) with YoY comparison; `financial-report --latest` for key indicator summary
+- **`valuation-rank`** — daily PE/PB/PS industry percentile rank over a date range
+- **`institution-rating --history` / `--industry-rank`** — analyst rating history and industry-wide analyst coverage ranking
+- **`news search` / `topic search`** — keyword search across news and community topics
+- **`bank-cards`**, **`withdrawals`**, **`deposits`** — account management commands for linked cards and transaction history
+- **`portfolio short-margin`** — short-selling margin deposit details per position
+
 ## 2026-05-05
 
 ### CLI v0.19.2

--- a/docs/en/docs/cli/release-notes.md
+++ b/docs/en/docs/cli/release-notes.md
@@ -7,6 +7,12 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.20.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.20.3)
+
+- **Breaking: `analyst-estimates` removed** — command has been removed; the same data is available via `consensus` (EPS and revenue estimates)
+- **Fix: HK symbol leading zeros** — inputs like `00700.HK` or `09988.HK` now correctly resolve to `700.HK` / `9988.HK`; `operating` updated to reflect HK-only data coverage
+- **Fix: `ipo detail`** — auto-detects market from symbol suffix (`SUJA.US` → US, `700.HK` → HK), so `--market` is no longer required; cleaner error message when no IPO data is found; Payment Deadline formatted as RFC 3339
+
 ### [v0.20.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.20.2)
 
 - **Fix: `institution-rating --history`** — restructured as a proper table with logical column ordering; timestamps formatted as `YYYY-MM-DD`; price targets rounded to 2 decimal places; `evaluate_history` capped to 20 most recent records

--- a/docs/zh-CN/docs/changelog.md
+++ b/docs/zh-CN/docs/changelog.md
@@ -6,6 +6,18 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-05-08
+
+### CLI v0.20.0
+
+- **`ipo` 命令组** — 港股完整 IPO 工具（`subscriptions`、`wait-listing`、`listed`、`calendar`、`detail`、`orders`、`profit-loss`），美股支持 `us-subscriptions`、`us-wait-listing`、`us-listed`
+- **`financial-statement`** — 完整逐行财务报表（利润表 / 资产负债表 / 现金流量表），含层级结构与 YoY 对比；`financial-report --latest` 快速获取关键指标摘要
+- **`valuation-rank`** — 每日 PE/PB/PS 行业百分位排名
+- **`institution-rating --history` / `--industry-rank`** — 分析师评级变化历史与行业覆盖排名
+- **`news search` / `topic search`** — 关键词搜索资讯和社区话题
+- **`bank-cards`**、**`withdrawals`**、**`deposits`** — 银行卡及出入金记录查询
+- **`portfolio short-margin`** — 各持仓融券保证金明细
+
 ## 2026-05-05
 
 ### CLI v0.19.2

--- a/docs/zh-CN/docs/cli/release-notes.md
+++ b/docs/zh-CN/docs/cli/release-notes.md
@@ -7,6 +7,12 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.20.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.20.3)
+
+- **Breaking：移除 `analyst-estimates` 命令** — 该命令已下线；EPS 和营收预测数据请改用 `consensus`
+- **修复：港股代码前导零** — `00700.HK`、`09988.HK` 等格式现在可正确解析为 `700.HK`、`9988.HK`；`operating` 命令说明更新，明确仅支持港股
+- **修复：`ipo detail`** — 自动从代码后缀识别市场（如 `SUJA.US` → 美股，`700.HK` → 港股），不再需要 `--market` 参数；找不到 IPO 数据时提示更友好；缴款截止日期改为 RFC 3339 格式
+
 ### [v0.20.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.20.2)
 
 - **修复：`institution-rating --history` 输出格式** — 改为表格布局，列顺序更合理；时间戳格式化为 `YYYY-MM-DD`；目标价保留 2 位小数；`evaluate_history` 仅展示最近 20 条记录

--- a/docs/zh-HK/docs/changelog.md
+++ b/docs/zh-HK/docs/changelog.md
@@ -6,6 +6,18 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-05-08
+
+### CLI v0.20.0
+
+- **`ipo` 指令組** — 港股完整 IPO 工具（`subscriptions`、`wait-listing`、`listed`、`calendar`、`detail`、`orders`、`profit-loss`），美股支援 `us-subscriptions`、`us-wait-listing`、`us-listed`
+- **`financial-statement`** — 完整逐行財務報表（損益表 / 資產負債表 / 現金流量表），含層級結構與 YoY 對比；`financial-report --latest` 快速獲取關鍵指標摘要
+- **`valuation-rank`** — 每日 PE/PB/PS 行業百分位排名
+- **`institution-rating --history` / `--industry-rank`** — 分析師評級變化歷史與行業覆蓋排名
+- **`news search` / `topic search`** — 關鍵詞搜尋資訊和社區話題
+- **`bank-cards`**、**`withdrawals`**、**`deposits`** — 銀行卡及出入金記錄查詢
+- **`portfolio short-margin`** — 各持倉融券保證金明細
+
 ## 2026-05-05
 
 ### CLI v0.19.2

--- a/docs/zh-HK/docs/cli/release-notes.md
+++ b/docs/zh-HK/docs/cli/release-notes.md
@@ -7,6 +7,12 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.20.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.20.3)
+
+- **Breaking：移除 `analyst-estimates` 指令** — 該指令已下線；EPS 及營收預測數據請改用 `consensus`
+- **修復：港股代碼前導零** — `00700.HK`、`09988.HK` 等格式現在可正確解析為 `700.HK`、`9988.HK`；`operating` 指令說明更新，明確僅支援港股
+- **修復：`ipo detail`** — 自動從代碼後綴識別市場（如 `SUJA.US` → 美股，`700.HK` → 港股），不再需要 `--market` 參數；找不到 IPO 資料時提示更友好；繳款截止日期改為 RFC 3339 格式
+
 ### [v0.20.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.20.2)
 
 - **修復：`institution-rating --history` 輸出格式** — 改為表格版面，欄位順序更合理；時間戳格式化為 `YYYY-MM-DD`；目標價保留 2 位小數；`evaluate_history` 僅顯示最近 20 條記錄


### PR DESCRIPTION
## Summary

- Add CLI v0.20.3 release notes (3 languages): `analyst-estimates` removal, HK symbol leading-zero fix, `ipo detail` auto-market detection
- Backfill CLI v0.20.0 changelog entry (3 languages): `ipo` command group, `financial-statement`, `valuation-rank`, `institution-rating` new flags, search commands, account commands

## Changes

- `docs/{en,zh-CN,zh-HK}/docs/cli/release-notes.md` — v0.20.3 entry added at top
- `docs/{en,zh-CN,zh-HK}/docs/changelog.md` — v0.20.0 entry added (changelog only tracks major versions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)