### PR TITLE
docs(skill): add Claude Code permission tip for Bash(longbridge *) in install guide

### DIFF
--- a/docs/.vitepress/theme/components/NewHomePage/ProductSkill.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/ProductSkill.vue
@@ -26,7 +26,7 @@ const agents = [
   },
 ]
 
-const SEMANTIC_TEXT = `Install Longbridge Skill following the guide:\nhttps://open.longbridge.com/skill/install.md`
+const SEMANTIC_TEXT = `Install Longbridge AI toolkit following the guide:\nhttps://open.longbridge.com/skill/install.md`
 
 const cliTabs = [
   { label: 'bun', cmd: 'bunx skills add longbridge/skills -g' },
@@ -159,7 +159,7 @@ function copyCli() {
       <p class="skill-install-label">Copy and send to any AI — it will walk you through the installation:</p>
       <div class="skill-install-ai-block">
         <div class="skill-install-ai-text">
-          <span>Install Longbridge Skill following the guide:</span>
+          <span>Install Longbridge AI toolkit following the guide:</span>
           <span class="skill-install-ai-url">https://open.longbridge.com/skill/install.md</span>
         </div>
         <button class="skill-copy-btn" @click="copySemantic">

--- a/docs/.vitepress/theme/components/Skill.vue
+++ b/docs/.vitepress/theme/components/Skill.vue
@@ -2232,10 +2232,10 @@ const openclawCommand = '/skills add longbridge/skills'
 import { siteHostname } from '../utils/region'
 const oneLinerCommand = computed(() =>
   isEN.value
-    ? `Install Longbridge Skill following the guide: \n${siteHostname}/skill/install.md`
+    ? `Install Longbridge AI toolkit following the guide: \n${siteHostname}/skill/install.md`
     : isHK.value
-      ? `根據指引安裝 Longbridge SKILL：\n${siteHostname}/skill/install.md`
-      : `根据指引安装 Longbridge SKILL：\n${siteHostname}/skill/install.md`
+      ? `根據指引安裝 Longbridge AI toolkit：\n${siteHostname}/skill/install.md`
+      : `根据指引安装 Longbridge AI toolkit：\n${siteHostname}/skill/install.md`
 )
 
 const copiedNpx = ref(false)

--- a/docs/en/skill/install/index.md
+++ b/docs/en/skill/install/index.md
@@ -73,6 +73,16 @@ longbridge auth login
 
 That's it. The AI can now call `longbridge` commands on your behalf.
 
+**Claude Code users:** The first time Claude runs a `longbridge` command, it will ask for permission. To allow all Longbridge commands without repeated prompts, add this to `.claude/settings.json` in your project (create the file if it doesn't exist):
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(longbridge *)"]
+  }
+}
+```
+
 > See the [CLI reference](/docs/cli) for the full command list and installation details.
 
 ### Method B — MCP

--- a/docs/zh-CN/skill/install/index.md
+++ b/docs/zh-CN/skill/install/index.md
@@ -71,6 +71,16 @@ longbridge auth login
 
 完成后，AI 即可代你调用 `longbridge` 命令。
 
+**Claude Code 用户：** Claude 首次运行 `longbridge` 命令时会弹出权限确认提示。若要避免每次都被询问，可在项目的 `.claude/settings.json` 中添加以下配置（文件不存在时新建）：
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(longbridge *)"]
+  }
+}
+```
+
 > 详细安装说明及完整命令列表参见 [CLI 文档](/zh-CN/docs/cli)。
 
 ### 方式 B：MCP

--- a/docs/zh-HK/skill/install/index.md
+++ b/docs/zh-HK/skill/install/index.md
@@ -71,6 +71,16 @@ longbridge auth login
 
 完成後，AI 即可代你調用 `longbridge` 命令。
 
+**Claude Code 用戶：** Claude 首次執行 `longbridge` 指令時會彈出權限確認提示。若要避免每次都被詢問，可在專案的 `.claude/settings.json` 中新增以下配置（文件不存在時新建）：
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(longbridge *)"]
+  }
+}
+```
+
 > 詳細安裝說明及完整指令列表參見 [CLI 文檔](/zh-HK/docs/cli)。
 
 ### 方式 B：MCP


### PR DESCRIPTION
## Summary

- 在 Skill 安装指引（Method A CLI 章节）新增 Claude Code 专属提示
- 说明如何在 `.claude/settings.json` 中配置 `Bash(longbridge *)` 权限，避免 Claude 每次调用 `longbridge` 命令时弹出权限确认
- 三语言版本（en / zh-CN / zh-HK）同步更新

## Test plan

- [ ] 确认三语言页面渲染正常，JSON 代码块格式正确
- [ ] 确认提示位置在 `longbridge auth login` 步骤之后、CLI 文档链接之前

🤖 Generated with [Claude Code](https://claude.com/claude-code)