### PR TITLE
design: 更新 Logo、优化 footer 间距与视觉细节

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -356,7 +356,86 @@ Longbridge's shadow system uses **layered, soft shadows** that increase in blur 
 - **Form Fields:** Input height remains `60px` but width adapts from constrained (`400px` max) on desktop to full-width minus `32px` on mobile
 - **Modal Width:** Constrained to `600px` on desktop and tablet; full-width minus `16px` margins on mobile (max `100vw - 32px`)
 
-## 9. Agent Prompt Guide
+## 9. Implemented CSS Token Layer (`--lb-*`)
+
+All design decisions are encoded as CSS custom properties in `docs/.vitepress/theme/style/css-var.scss`. These tokens take precedence and should be referenced in all component styles.
+
+### Light Mode (`:root`)
+
+```scss
+/* Buttons */
+--lb-btn-primary-bg: #000000;
+--lb-btn-primary-color: #ffffff;
+--lb-btn-primary-radius: 9999px;
+--lb-btn-primary-h: 36px;
+--lb-btn-primary-fs: 14px;
+--lb-btn-primary-fw: 500;
+--lb-btn-secondary-bg: rgba(210, 210, 210, 0.6);
+--lb-btn-secondary-color: #374151;
+--lb-btn-secondary-radius: 30px;
+
+/* Cards */
+--lb-card-border: #e5e7eb;
+--lb-card-radius: 12px;
+--lb-card-shadow-1: rgba(0, 0, 0, 0.04) 0px 2px 8px;
+--lb-card-shadow-2: rgba(0, 0, 0, 0.09) 0px 8px 24px;
+
+/* Badge */
+--lb-badge-fs: 12px;
+--lb-badge-fw: 600;
+--lb-badge-lh: 1;
+--lb-badge-py: 4px;
+--lb-badge-px: 8px;
+--lb-badge-radius: 9999px;
+```
+
+### Dark Mode (`.dark`)
+
+```scss
+--lb-btn-primary-bg: #ffffff;
+--lb-btn-primary-color: #000000;
+--lb-btn-secondary-bg: rgba(80, 80, 80, 0.5);
+--lb-btn-secondary-color: #d1d5db;
+--lb-card-border: rgba(255, 255, 255, 0.1);
+```
+
+### Component-Level Implementation Notes
+
+**Navigation Logo**
+- Light: `https://assets.wbrks.com/uploads/e76f6d93-.../longbridge-developers-light.png`
+- Dark: `https://assets.wbrks.com/uploads/37a18fa4-.../longbridge-developers-dark.png`
+- Width: `145px` via CSS (`.VPNavBarTitle .logo { width: 145px; height: auto; }` in `custom.scss`)
+- `siteTitle: false` in VitePress config to hide the text beside the logo
+
+**Hero CTA Buttons** (`NewHomePage/HeroSection.vue`)
+- Primary: black pill (`--lb-btn-primary-*`), hover opacity `0.82`
+- Secondary: gray pill (`--lb-btn-secondary-*`), hover gap widens from `0.375rem` to `0.625rem`
+
+**GetStarted Cards** (`NewHomePage/GetStarted.vue`)
+- Icon wrap: `40×40px`, `border-radius: 10px`, per-card color via inline CSS vars `--icon-color / --icon-bg / --icon-bg-dark`
+- Dark mode icon bg: `color-mix(in srgb, iconColor 15%, var(--vp-c-bg-soft))`
+- Hover: `box-shadow: var(--lb-card-shadow-2)` + `translateY(-3px)` — **no border color change**
+
+**OpenAPI SDK Bento Cards** (`NewHomePage/ProductOpenAPI.vue`)
+- Background: `var(--vp-c-bg)` — **no gray soft background**
+- Hover: lift + shadow only — **no border color change**
+
+**Skill Page Badge** (`Skill.vue`)
+- Filled pill: `background: color-mix(in srgb, var(--vp-c-brand-1) 12%, transparent)`; text `var(--vp-c-brand-1)`
+- Uses `--lb-badge-*` tokens
+
+**Skill Chat Window Border**
+- Uses `--lb-card-border` (light: `#e5e7eb`, dark: `rgba(255,255,255,0.1)`)
+
+**Footer Spacing**
+- Homepage (`NewHomePage/Footer.vue`): `padding: 1.25rem 0 2.5rem` — extra bottom breathing room
+- Doc pages (`HomePage/Footer.vue`): `pt-4 pb-8 mt-6` — tighter top margin, generous bottom padding
+- `LayoutInner.vue` page-bottom slot: Footer skipped for `new-home-page` pageClass to avoid double footer
+
+**Pricing Badge**
+- `text-[12px] font-semibold px-2 py-1 rounded-full leading-none whitespace-nowrap`
+
+## 10. Agent Prompt Guide
 
 ### Quick Color Reference
 - **Primary CTA:** Black (`#000000`) with white text

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,398 @@
+# Design System Inspired by Longbridge Singapore
+
+## 1. Visual Theme & Atmosphere
+
+Longbridge's design system embodies a **modern fintech aesthetic** with clean, professional lines and a forward-thinking digital-first approach. The visual language balances sophistication with accessibility, combining a deep navy foundation with vibrant cyan accents that evoke innovation, trust, and energy in financial markets. The design prioritizes clarity and efficiency, using ample whitespace and a restrained color palette to reduce cognitive load while maintaining visual interest through strategic use of gradients and layered depth effects. The overall atmosphere is professional yet approachable—designed for serious investors who appreciate cutting-edge technology and seamless user experiences.
+
+**Key Characteristics**
+- Clean, minimalist aesthetic with strategic use of negative space
+- Deep navy (`#0F1729`) as the dominant dark anchor paired with cyan (`#00B8B8`) for dynamic accents
+- Modern sans-serif typography with clear hierarchy and generous spacing
+- Subtle elevation and glassmorphic effects for contemporary depth
+- High contrast for accessibility and readability
+- Playful yet professional tone through icon illustration and gradient overlays
+- Mobile-first responsive design optimized for trading workflows
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Longbridge Navy** (`#0F1729`): Primary background and text color for main UI surface; used across headers, navigation, and high-emphasis content
+- **Longbridge Dark** (`#0A0E19`): Darker variant for enhanced depth; used in overlay backgrounds and secondary surfaces
+- **Pure Black** (`#000000`): Maximum contrast for critical text and borders; used sparingly for headings and high-priority CTAs
+
+### Accent Colors
+- **Cyan Accent** (`#00B8B8`): Primary highlight and call-to-action indicator; draws attention to key market data, interactive elements, and feature highlights
+- **Sky Blue** (`#2A99FE`): Secondary accent for alternative actions and interactive states; used in charts, links, and supplementary CTAs
+
+### Interactive
+- **Error/Danger** (`#FF3A3A`): Loss indicators, error states, and critical warnings; primarily used for negative market movements and validation errors
+- **Warning Bright** (`#FF9D3A`): Medium-priority warnings and cautionary states; used for important notifications and attention-grabbing alerts
+- **Warning Medium** (`#FFBD3A`): Alternative warning tone for less critical alerts; used in secondary warning contexts
+- **Warning Light** (`#FFE13A`): Softest warning state for background highlights and low-priority notifications
+
+### Neutral Scale
+- **Gray 900** (`#111827`): Dense text and borders; used for secondary headings and emphasized body copy
+- **Gray 600** (`#374151`): Medium-contrast text for supplementary information; used in descriptions and helper text
+- **Gray 500** (`#9CA3AF`): Light text for disabled states and tertiary information; used in form labels and placeholder text
+- **Gray 300** (`#D1D5DB`): Subtle dividers and border lines; used for section separators and form field borders
+- **Gray 200** (`#E5E7EB`): Light background tint and border; heavily used for input fields, dividers, and subtle surface variations
+- **Gray 100** (`#EAEBEC`): Barely perceptible background tint; used for very subtle backgrounds and hover states
+- **Off-White** (`#F8F9FA`): Near-white background for secondary sections and light surfaces
+- **Pure White** (`#FFFFFF`): Clean background and card surfaces; maximum contrast baseline
+
+### Surface & Borders
+- **Light Border** (`#C7CACC`): Subtle borders for form elements and container outlines
+- **Border Medium** (`#82888D`): Medium-weight borders for input fields and card separators
+
+## 3. Typography Rules
+
+### Font Family
+**Primary:** `Cera Pro` with fallback `serif` — used for display and heading hierarchy; conveys premium, confident brand personality  
+**Secondary:** `ui-sans-serif` (system font stack including `-apple-system`, `BlinkMacSystemFont`, `Segoe UI`, `Roboto`, `Helvetica Neue`, `Arial`, sans-serif) — used for body copy, buttons, and navigation; ensures optimal performance and platform consistency  
+**Tertiary:** `SF Pro Display` — used for large interactive elements and input fields; refined appearance on Apple devices
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|-----------------|-------|
+| Display 1 (H1) | Cera Pro | 48px | 700 | 48px | 0px | Page hero and major section headings; maximum impact and presence |
+| Heading 2 (H2) | ui-sans-serif | 48px | 600 | 48px | 0px | Large section headers; slightly less weight than Display for subordinate emphasis |
+| Heading 3 (H3) | SF Pro Display | 24px | 700 | 32px | 0px | Subsection headers and card titles; strong visual hierarchy |
+| Heading 4 (H4) | SF Pro Display | 18px | 700 | 28px | 0px | Minor section headers and prominent labels; maintains hierarchy depth |
+| Body Large | ui-sans-serif | 16px | 400 | 24px | 0px | Primary body copy for lists and main content blocks |
+| Body Regular | ui-sans-serif | 14px | 400 | 20px | 0px | Default body copy for paragraphs and descriptions; most common text role |
+| Button Text | ui-sans-serif | 16px | 500 | 20px | 0px | Call-to-action and interactive buttons; medium weight for emphasis |
+| Small/Caption | ui-sans-serif | 14px | 400 | 20px | 0px | Captions, helper text, and fine print; reduced size for secondary information |
+| Input Label | SF Pro Display | 20px | 400 | 28px | 0px | Large input fields and text entry areas; optimized for touch targets |
+| Code | Monospace (default system) | 12px | 400 | 16px | 0.5px | Code snippets and technical references; ensures proper character spacing |
+
+### Principles
+- **Contrast First:** Every text element maintains sufficient contrast against its background to meet WCAG AA standards (minimum 4.5:1 for body, 3:1 for large text)
+- **Weight as Hierarchy:** Font weight differentiates importance—bold (700) for headlines, medium (600) for secondary headers, regular (400) for body copy
+- **Generous Line Height:** Line heights exceed font size by 25–67% to maximize readability and reduce eye strain, especially critical for financial data
+- **Serif + Sans Blend:** Premium Cera Pro headings paired with accessible system sans-serif creates visual distinction while maintaining performance
+- **Mobile Optimization:** All font sizes remain readable at 14px minimum; input fields use larger 20px for comfortable touch interaction
+- **Color Integration:** Font color closely follows semantic hierarchy—navy (`#0F1729`) for primary content, grays for secondary, cyan (`#00B8B8`) for interactive elements
+
+## 4. Component Stylings
+
+### Buttons
+
+**Primary Button (Full Width CTA)**
+- **Background:** `#000000` (solid black)
+- **Text Color:** `#FFFFFF` (pure white)
+- **Font Size:** `16px`
+- **Font Weight:** `500`
+- **Font Family:** `ui-sans-serif`
+- **Padding:** `12px 24px`
+- **Border Radius:** `9999px` (fully rounded/pill shape)
+- **Border:** None (`1px solid transparent`)
+- **Box Shadow:** `rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0.07) 0px 4px 16px 0px`
+- **Height:** `40px`
+- **Line Height:** `20px`
+- **Hover State:** Reduce opacity to `0.85`; increase shadow to `rgba(0, 0, 0, 0.12) 0px 6px 20px 0px`
+- **Active State:** Reduce opacity to `0.75`; maintain shadow
+- **Disabled State:** Opacity `0.5`; cursor not-allowed
+
+**Secondary Button (Outline)**
+- **Background:** `rgba(210, 210, 210, 0.6)` (translucent light gray)
+- **Text Color:** `#0F1729` (navy)
+- **Font Size:** `16px`
+- **Font Weight:** `400`
+- **Font Family:** `ui-sans-serif`
+- **Padding:** `8px 16px`
+- **Border Radius:** `30px`
+- **Border:** `1px solid rgba(0, 0, 0, 0.1)` (subtle dark border)
+- **Box Shadow:** `rgba(0, 0, 0, 0.07) 0px 4px 16px 0px`
+- **Height:** `40px`
+- **Line Height:** `24px`
+- **Hover State:** Background `rgba(210, 210, 210, 0.8)`; shadow `rgba(0, 0, 0, 0.1) 0px 6px 20px 0px`
+- **Active State:** Background `rgba(210, 210, 210, 1)`
+- **Disabled State:** Opacity `0.5`
+
+**Icon Button (Navigation)**
+- **Background:** `rgba(210, 210, 210, 0.6)`
+- **Text Color:** `#0F1729`
+- **Font Size:** `16px` or `14px` (depends on context)
+- **Font Weight:** `400` or `500`
+- **Font Family:** `ui-sans-serif`
+- **Padding:** `0px` (icon-only, no text padding)
+- **Border Radius:** `30px` (rounded pill)
+- **Border:** `1px solid rgba(0, 0, 0, 0.1)`
+- **Box Shadow:** `rgba(0, 0, 0, 0.07) 0px 4px 16px 0px`
+- **Width & Height:** `40px` (square/circular)
+- **Hover State:** Background `rgba(210, 210, 210, 0.8)`
+- **Active State:** Background `rgba(0, 0, 0, 0.1)`
+
+### Cards & Containers
+
+**Feature Card (Product Showcase)**
+- **Background:** Linear gradient from `#0A0E19` to `#1A2847` with opacity-layered cyan (`rgba(0, 184, 184, 0.1)`)
+- **Text Color:** `#FFFFFF` (white headings), `#E5E7EB` (body)
+- **Padding:** `24px` to `32px`
+- **Border Radius:** `16px` to `24px`
+- **Border:** `1px solid rgba(0, 184, 184, 0.2)` (subtle cyan border)
+- **Box Shadow:** `rgba(0, 0, 0, 0.2) 0px 8px 32px 0px`
+- **Hover State:** Border opacity increases to `0.3`; shadow becomes `rgba(0, 184, 184, 0.15) 0px 12px 40px 0px`
+
+**Standard Card**
+- **Background:** `#FFFFFF` (pure white)
+- **Text Color:** `#0F1729` (navy)
+- **Padding:** `16px` to `24px`
+- **Border Radius:** `12px`
+- **Border:** `1px solid #E5E7EB` (light gray)
+- **Box Shadow:** `rgba(0, 0, 0, 0.05) 0px 2px 8px 0px`
+- **Hover State:** Shadow `rgba(0, 0, 0, 0.1) 0px 4px 16px 0px`
+
+### Inputs & Forms
+
+**Text Input Field**
+- **Background:** `rgba(0, 0, 0, 0)` (transparent) or `#F8F9FA` on white backgrounds
+- **Text Color:** `#FFFFFF` (white text on dark backgrounds) or `#0F1729` on light backgrounds
+- **Font Size:** `20px`
+- **Font Weight:** `400`
+- **Font Family:** `SF Pro Display`
+- **Padding:** `12px 16px`
+- **Border Radius:** `8px`
+- **Border:** `1px solid #E5E7EB` (light gray) or `rgba(229, 231, 235, 0.3)` (transparent variant)
+- **Box Shadow:** None (or `inset rgba(0, 0, 0, 0.02) 0px 1px 3px 0px` for subtle depth)
+- **Height:** `60px` (generous for touch interaction)
+- **Line Height:** `28px`
+- **Focus State:** Border `1px solid #00B8B8` (cyan); box shadow `inset rgba(0, 184, 184, 0.1) 0px 0px 0px 3px`
+- **Placeholder Text:** Color `#9CA3AF` (gray 500); opacity `0.7`
+- **Disabled State:** Background `#EAEBEC`; color `#9CA3AF`; cursor not-allowed
+
+**Checkbox/Radio Input**
+- **Size:** `20px × 20px`
+- **Border:** `2px solid #E5E7EB`
+- **Border Radius:** `4px` (checkbox) or `50%` (radio)
+- **Background (unchecked):** `#FFFFFF`
+- **Background (checked):** `#00B8B8` (cyan)
+- **Checkmark/Dot Color:** `#FFFFFF`
+- **Focus State:** Box shadow `0px 0px 0px 3px rgba(0, 184, 184, 0.2)`
+
+### Navigation
+
+**Header Navigation Menu**
+- **Background:** `rgba(0, 0, 0, 0)` (transparent) or `#FFFFFF` with subtle border-bottom
+- **Text Color:** `#0F1729` (navy)
+- **Font Size:** `16px`
+- **Font Weight:** `400`
+- **Font Family:** `ui-sans-serif`
+- **Height:** `40px` to `64px` (including padding)
+- **Padding:** `0px 16px` (horizontal), `12px 0px` (vertical)
+- **Border Radius:** `0px` (linear navigation)
+- **Border:** `1px solid #E5E7EB` (subtle bottom border on scroll)
+- **Box Shadow:** None (or `rgba(0, 0, 0, 0.04) 0px 2px 8px 0px` on scroll)
+- **Link Hover State:** Text color `#00B8B8` (cyan); underline appears
+- **Active Link:** Text color `#00B8B8`; underline `2px solid #00B8B8`
+- **Dropdown Trigger:** Icon rotates `180deg` on open
+
+**Mobile Navigation (Hamburger Menu)**
+- **Icon Size:** `24px × 24px`
+- **Icon Color:** `#0F1729` (navy)
+- **Menu Background:** `#FFFFFF`
+- **Menu Item Padding:** `16px 20px`
+- **Menu Item Height:** `48px`
+- **Divider:** `1px solid #E5E7EB`
+- **Hover State:** Background `#F8F9FA`
+
+### Links
+
+**Text Link (Body)**
+- **Color:** `#2A99FE` (sky blue) or `#00B8B8` (cyan for primary)
+- **Text Decoration:** None (underline on hover)
+- **Font Size:** `14px` to `16px`
+- **Font Weight:** `400`
+- **Hover State:** Text decoration `underline`; opacity `0.8`
+- **Visited State:** Color `#8B5CF6` (purple) if applicable
+- **Active State:** Color intensifies; underline remains
+
+**Navigation Link (Header)**
+- **Color:** `#0F1729` (navy, default)
+- **Font Size:** `16px`
+- **Font Weight:** `400`
+- **Padding:** `8px 0px`
+- **Hover State:** Color `#00B8B8` (cyan); underline `1px solid #00B8B8`
+- **Active State:** Color `#00B8B8`; underline persistent
+
+### Badge & Status Indicators
+
+**Badge (Success/Active)**
+- **Background:** `rgba(0, 184, 184, 0.1)` (cyan tint)
+- **Text Color:** `#00B8B8` (cyan)
+- **Font Size:** `12px`
+- **Font Weight:** `600`
+- **Padding:** `4px 8px`
+- **Border Radius:** `9999px` (fully rounded)
+- **Border:** `1px solid #00B8B8`
+
+**Badge (Error)**
+- **Background:** `rgba(255, 58, 58, 0.1)` (red tint)
+- **Text Color:** `#FF3A3A` (error red)
+- **Font Size:** `12px`
+- **Font Weight:** `600`
+- **Padding:** `4px 8px`
+- **Border Radius:** `9999px`
+- **Border:** `1px solid #FF3A3A`
+
+**Badge (Warning)**
+- **Background:** `rgba(255, 157, 58, 0.1)` (orange tint)
+- **Text Color:** `#FF9D3A` (warning orange)
+- **Font Size:** `12px`
+- **Font Weight:** `600`
+- **Padding:** `4px 8px`
+- **Border Radius:** `9999px`
+- **Border:** `1px solid #FF9D3A`
+
+## 5. Layout Principles
+
+### Spacing System
+The design system uses an **8px base unit** with a modular scale to maintain visual rhythm and consistency across all components.
+
+- **Micro:** `4px` — Tightest spacing between icons and text; gap within compact button groups
+- **XS:** `8px` — Padding in buttons and form fields; gap between inline elements
+- **Small:** `12px` — Gap in form field groups; spacing around small badges
+- **Base:** `16px` — Standard padding for cards and containers; margin between sections
+- **Medium:** `20px` — Margin between major content blocks; padding on modal dialogs
+- **Large:** `24px` — Padding for primary sections; margin between page regions
+- **XL:** `32px` — Generous padding on hero sections; margin between major layout sections
+- **2XL:** `40px` — Spacing around page containers; margin above footer
+- **3XL:** `48px` — Large whitespace between feature sections
+- **4XL:** `56px` — Section break spacing on desktop
+- **5XL:** `60px` — Maximum breathing room between major content zones
+
+### Grid & Container
+- **Max Width:** `1200px` to `1440px` for desktop content containers (varies by page section)
+- **Column Strategy:** 12-column grid system; cards and content blocks span 1–4 columns
+- **Gutter Width:** `24px` horizontal spacing between columns
+- **Container Padding:** `16px` (mobile), `24px` (tablet), `32px` (desktop) on all sides
+- **Section Patterns:**
+  - Hero sections: Full width with centered content within `1200px` max-width container
+  - Feature grids: Responsive 1–4 column layout using CSS Grid with auto-fit
+  - Feature cards: 4 columns on desktop, 2 on tablet, 1 on mobile
+  - Stacked content: Full width with internal max-width constraints
+
+### Whitespace Philosophy
+The design system prioritizes **generous whitespace** to reduce cognitive load and draw focus to critical information. Every major section is surrounded by at least `32px` vertical spacing, with `48px` typical between page regions. Within cards, padding scales from `16px` (compact) to `32px` (expansive), ensuring content never feels cramped. Text lines benefit from `1.4–1.5x` font-size line heights, creating airy, scannable paragraphs. Horizontal spacing uses the same restraint—buttons rarely sit closer than `12px` apart, and form fields always maintain `16px` minimum gap to their labels.
+
+### Border Radius Scale
+- **None:** `0px` — Linear elements like dividers and underlines
+- **Small:** `4px` — Subtle corner softening on input fields and small containers
+- **Medium:** `8px` — Standard radius for cards, modals, and standard containers
+- **Large:** `12px` — Prominent radius for feature cards and call-to-action sections
+- **XL:** `16px` to `24px` — Large container cards and hero backgrounds
+- **Full:** `9999px` — Buttons, badges, and circular icon containers; creates pill-shaped appearance
+- **Alternate:** `30px` — Secondary button radius; creates distinct rounded appearance between primary and secondary CTAs
+- **Alternative 2:** `23px` — Tertiary button variant; subtle variation in rounding
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| **Flat (Level 0)** | No shadow; solid background | Base surfaces, dividers, input fields in neutral states |
+| **Raised (Level 1)** | `rgba(0, 0, 0, 0.04) 0px 2px 8px 0px` | Standard cards, buttons at rest, subtle elevation |
+| **Floating (Level 2)** | `rgba(0, 0, 0, 0.07) 0px 4px 16px 0px` | Interactive buttons, secondary cards, hover states |
+| **Elevated (Level 3)** | `rgba(0, 0, 0, 0.12) 0px 8px 24px 0px` | Modal overlays, dropdown menus, emphasized components |
+| **Peak (Level 4)** | `rgba(0, 0, 0, 0.16) 0px 12px 32px 0px` | Floating action buttons, top-layer modals, critical alerts |
+| **Inset Shadow** | `inset rgba(0, 0, 0, 0.04) 0px 2px 4px 0px` | Pressed button states, sunken text inputs |
+| **Glow (Feature Cards)** | `rgba(0, 184, 184, 0.15) 0px 8px 32px 0px` (cyan glow) | Feature showcase cards, premium card variants; draws attention through color-specific shadow |
+
+**Shadow Philosophy:**
+Longbridge's shadow system uses **layered, soft shadows** that increase in blur radius and distance with elevation, creating a subtle sense of height and interaction feedback. Shadows are predominantly neutral (`rgba(0, 0, 0, ...)`) for standard elevation, but critical interactive elements like feature cards use **cyan-tinted shadows** (`rgba(0, 184, 184, ...)`) to reinforce brand identity and draw focus. Inset shadows are reserved for **pressed/active states**, creating tactile feedback without raising elevation. The system avoids harsh, high-contrast shadows—all blur radii exceed `8px` to create smooth, diffused light falloff.
+
+## 7. Do's and Don'ts
+
+### Do
+- **Use cyan (`#00B8B8`) strategically** for interactive elements, links, and primary CTAs to create visual focus and guide user attention
+- **Maintain minimum `40px` height** for all interactive elements (buttons, inputs) to ensure comfortable touch targets on mobile devices
+- **Apply generous spacing (`24px` minimum)** between sections to create breathing room and improve content scanability
+- **Leverage the navy (`#0F1729`) and white contrast** for maximum readability and accessible text; ensure 4.5:1 contrast ratio on all body copy
+- **Use system fonts** (`ui-sans-serif`) for body and navigation to prioritize performance and platform consistency
+- **Combine icons with text** in buttons and navigation for clarity; avoid icon-only CTAs for critical actions without accompanying labels
+- **Apply subtle hover states** (shadow elevation + opacity changes) to provide clear interactive feedback
+- **Use error, warning, and success** colors (`#FF3A3A`, `#FF9D3A`, `#00B8B8`) exclusively for semantic purposes—never decorative
+- **Stack content vertically on mobile** and use responsive typography (scale down heading sizes on small screens)
+- **Include loading states** and disabled states with reduced opacity (`0.5`) and cursor changes (`not-allowed`)
+
+### Don't
+- **Don't use more than 2–3 accent colors** in a single view; restrict to cyan (`#00B8B8`) and sky blue (`#2A99FE`) to maintain visual coherence
+- **Don't create buttons smaller than `40px` height** or with padding less than `8px`; minimize touch target confusion
+- **Don't apply shadows stronger than Level 2** (`rgba(0, 0, 0, 0.07)`) to standard components; reserve Level 3+ for modals and critical overlays
+- **Don't use light gray text** (`#9CA3AF` or lighter) for primary body copy; reserve for disabled states, captions, and placeholder text only
+- **Don't mix font families** within a single component; stick to `ui-sans-serif` for navigation/buttons and `SF Pro Display` for large inputs
+- **Don't apply rounded corners** (`border-radius > 0`) to linear navigation elements; maintain `0px` radius for horizontal menu bars
+- **Don't use cyan or error colors** in text links unless specifically indicating interactive state or error condition
+- **Don't exceed `1440px` container max-width**; keep content scannable and prevent excessive line lengths
+- **Don't override button padding** arbitrarily; maintain `8px–16px` horizontal padding scale for consistency
+- **Don't animate non-interactive elements**; reserve transitions (200–300ms) for buttons, links, and form fields only
+- **Don't use background gradients** on static text or small components; reserve gradient overlays for feature cards and hero sections only
+
+## 8. Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|------|-------|-------------|
+| **Mobile** | `0px – 640px` | Single-column layout; `16px` container padding; font sizes reduce by 1–2px; button height remains `40px`; navigation collapses to hamburger menu |
+| **Tablet** | `641px – 1024px` | Two-column grid; `24px` container padding; feature cards display 2-up; font sizes remain stable; navigation remains horizontal with limited dropdown expansion |
+| **Desktop** | `1025px – 1440px` | Full 4-column grid or 3-column where applicable; `32px` container padding; all interactive elements at full size; navigation fully expanded; modals centered and constrained to `600px` max-width |
+| **Large Desktop** | `1441px+` | Max-width container (`1440px`) applied; center-aligned content; additional spacing around page edges |
+
+### Touch Targets
+- **Minimum Size:** `40px × 40px` for all interactive elements (buttons, icon buttons, form fields)
+- **Minimum Spacing:** `12px` between adjacent interactive elements; `16px` preferred for comfortable thumb navigation
+- **Label Spacing:** Form labels must sit `8px` above input fields; labels must be at least `14px` font size for readability
+- **Link Tap Area:** Text links should include `8px` padding above/below to create comfortable tap zones
+- **Scrollable Lists:** List items must be minimum `44px` height; `56px` preferred for trading data and financial lists
+
+### Collapsing Strategy
+- **Hero Headings:** H1 size reduces from `48px` (desktop) → `36px` (tablet) → `28px` (mobile); maintain `1:1` line height
+- **Body Copy:** Remains `14px–16px` across all breakpoints for optimal readability; never reduce below `12px`
+- **Buttons:** Height remains fixed at `40px` across all breakpoints; width adapts from fixed (`120px+`) on desktop to full-width on mobile with `16px` margins
+- **Navigation:** Desktop horizontal menu (`ui-sans-serif`, `16px`, full width) → Tablet compact menu (reduced padding, limited dropdown) → Mobile hamburger menu (full-screen overlay, stacked items)
+- **Feature Cards Grid:** Desktop 4-column (using CSS Grid `grid-template-columns: repeat(auto-fit, minmax(280px, 1fr))`) → Tablet 2-column → Mobile single column (full width with `16px` margins)
+- **Spacing Collapse:** `32px` margins reduce to `24px` (tablet) and `16px` (mobile); maintain `8px` base unit consistency
+- **Form Fields:** Input height remains `60px` but width adapts from constrained (`400px` max) on desktop to full-width minus `32px` on mobile
+- **Modal Width:** Constrained to `600px` on desktop and tablet; full-width minus `16px` margins on mobile (max `100vw - 32px`)
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+- **Primary CTA:** Black (`#000000`) with white text
+- **Secondary CTA:** Light Gray (`#D2D2D2`) with Navy text (`#0F1729`)
+- **Accent & Focus:** Cyan (`#00B8B8`) — used for highlights, links, and interactive states
+- **Background (Dark):** Navy (`#0F1729`) — primary dark surface
+- **Background (Light):** White (`#FFFFFF`) — primary light surface
+- **Body Text:** Navy (`#0F1729`) on light backgrounds; White (`#FFFFFF`) on dark backgrounds
+- **Error State:** Red (`#FF3A3A`) — validation errors, negative market movement
+- **Warning State:** Orange (`#FF9D3A` or `#FFBD3A`) — alerts and cautionary content
+- **Heading Text:** Navy (`#0F1729`) or White (`#FFFFFF`) depending on background
+- **Disabled/Inactive:** Gray (`#9CA3AF`) text; opacity `0.5`
+- **Border:** Light Gray (`#E5E7EB`) — standard; Navy (`#0F1729`) at `0.1` opacity for subtle borders
+
+### Iteration Guide
+
+1. **Always use `#0F1729` (Navy) as the primary text color on light backgrounds and `#FFFFFF` (White) on dark backgrounds.** This ensures maximum contrast and readability across all surfaces.
+
+2. **Apply `#00B8B8` (Cyan) exclusively to interactive elements—links, focused inputs, primary buttons on secondary surfaces, and status indicators.** Never use cyan for decorative purposes.
+
+3. **Set minimum touch target size to `40px × 40px` and maintain `12px` spacing between adjacent interactive elements.** Verify this applies to all buttons, icon buttons, form fields, and link hit areas.
+
+4. **Use `ui-sans-serif` for navigation, buttons, and body copy; `SF Pro Display` for large input fields (`20px`); `Cera Pro` for headings only.** Font consistency is critical for performance and brand recognition.
+
+5. **Apply `24px` to `32px` vertical spacing between major sections; `16px` within card components; `8px` between tightly-grouped elements.** Never drop below `8px` base unit spacing.
+
+6. **Set button padding to `8px 16px` for standard buttons, adjust to `12px 24px` for prominent CTAs, and use `0px` padding for icon-only buttons.** Maintain `40px` height across all button variants.
+
+7. **Use `border-radius: 9999px` for pill-shaped buttons and badges; `30px` for secondary buttons; `8px–12px` for cards; `0px` for linear navigation elements.** Radius communicates component type and hierarchy.
+
+8. **Apply shadow elevation according to component type: Level 0 (none) for flat surfaces, Level 1 (`0px 2px 8px`) for standard cards, Level 2 (`0px 4px 16px`) for interactive states.** Use cyan-tinted shadows (`rgba(0, 184, 184, ...)`) only for feature showcase cards.
+
+9. **Restrict headline sizes to: `48px` (H1), `48px` (H2), `24px` (H3), `18px` (H4) on desktop; reduce by 10–20% on tablet and mobile, never below `14px` for any heading.** Maintain proportional line heights (`1:1` for headings, `1.4–1.5x` for body).
+
+10. **Test all components at `40px` minimum interactive height and verify `4.5:1` contrast ratio on body text.** Validate focus states include visible outlines or color changes; never remove outline on keyboard navigation.
+
+11. **Use responsive breakpoints: mobile (`≤640px`), tablet (`641–1024px`), desktop (`1025–1440px`).** Stack layouts vertically on mobile, enable 2-column on tablet, use full 4-column grid on desktop.
+
+12. **Implement loading, disabled, and error states for all form fields and buttons.** Disabled state: opacity `0.5`, cursor `not-allowed`; Error state: border `1px solid #FF3A3A`, text color `#FF3A3A`.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -76,7 +76,13 @@ export default defineConfig(
         ['meta', { property: 'og:url', content: `${siteHost}/${localePathname}` }],
         ['meta', { property: 'og:title', content: context.title }],
         ['meta', { property: 'og:description', content: context.description }],
-        ['meta', { name: 'twitter:image', content: 'https://assets.lbctrl.com/uploads/b510b04f-9238-4fe0-b39d-11e076876ac1/longbridge-og.png' }],
+        [
+          'meta',
+          {
+            name: 'twitter:image',
+            content: 'https://assets.lbctrl.com/uploads/b510b04f-9238-4fe0-b39d-11e076876ac1/longbridge-og.png',
+          },
+        ],
         ['meta', { name: 'twitter:title', content: context.title }],
         ['meta', { name: 'twitter:description', content: context.description }],
       ]
@@ -91,20 +97,15 @@ export default defineConfig(
       const tmpDir = resolve(__dirname, '../../.tmp-longbridge-skills')
       rmSync(tmpDir, { recursive: true, force: true })
       try {
-        execSync(
-          `git clone --depth 1 --branch main https://github.com/longbridge/skills.git "${tmpDir}"`,
-          { stdio: 'inherit' }
-        )
+        execSync(`git clone --depth 1 --branch main https://github.com/longbridge/skills.git "${tmpDir}"`, {
+          stdio: 'inherit',
+        })
       } catch (err) {
-        throw new Error(
-          `Failed to clone longbridge/skills@main: ${(err as Error).message}`
-        )
+        throw new Error(`Failed to clone longbridge/skills@main: ${(err as Error).message}`)
       }
       const skillsSrcDir = resolve(tmpDir, 'skills')
       if (!existsSync(skillsSrcDir)) {
-        throw new Error(
-          `longbridge/skills@main is missing the "skills/" directory; cannot build skill zips`
-        )
+        throw new Error(`longbridge/skills@main is missing the "skills/" directory; cannot build skill zips`)
       }
 
       // Pack all skills into longbridge-all.zip
@@ -166,11 +167,10 @@ export default defineConfig(
         text: 'Edit',
       },
       logo: {
-        light: 'https://assets.wbrks.com/assets/logo/light/logo.svg',
-        dark: 'https://assets.wbrks.com/assets/logo/dark/logo.svg',
-        width: 48,
-        height: 48,
+        light: 'https://assets.lbkrs.com/uploads/e76f6d93-80f8-4f9b-8b8d-2c86f0c94a78/longbridge-developers-light.png',
+        dark: 'https://assets.lbkrs.com/uploads/37a18fa4-46a4-408c-a36a-560004eb3cfb/longbridge-developers-dark.png',
       },
+      siteTitle: false,
       search: {
         provider: 'local',
       },

--- a/docs/.vitepress/theme/components/HomePage/Footer.vue
+++ b/docs/.vitepress/theme/components/HomePage/Footer.vue
@@ -74,7 +74,7 @@ const rightLinks = [
 
 <style scoped>
 .footer {
-  @apply text-sm py-5 mt-10 flex justify-between items-center w-full;
+  @apply text-sm pt-4 pb-8 mt-6 flex justify-between items-center w-full;
 }
 
 .beian-link,

--- a/docs/.vitepress/theme/components/NewHomePage/Footer.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/Footer.vue
@@ -76,7 +76,7 @@ const rightLinks = [
 <style scoped>
 .nhp-footer {
   border-top: 1px solid var(--vp-c-divider);
-  padding: 1.25rem 0;
+  padding: 1.25rem 0 2.5rem;
   margin-top: 0;
 }
 

--- a/docs/.vitepress/theme/components/NewHomePage/GetStarted.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/GetStarted.vue
@@ -8,16 +8,25 @@ const entries = [
     key: 'auth',
     href: '/docs/getting-started',
     icon: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>`,
+    iconColor: '#00b8b8',
+    iconBg: '#e0f7f5',
+    iconBgDark: 'color-mix(in srgb, #00b8b8 15%, var(--vp-c-bg-soft))',
   },
   {
     key: 'api',
     href: '/docs/api',
     icon: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M16 18l6-6-6-6"/><path d="M8 6l-6 6 6 6"/></svg>`,
+    iconColor: '#0ea5e9',
+    iconBg: '#e0f0ff',
+    iconBgDark: 'color-mix(in srgb, #0ea5e9 15%, var(--vp-c-bg-soft))',
   },
   {
     key: 'cli',
     href: '/docs/cli',
     icon: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>`,
+    iconColor: '#f97316',
+    iconBg: '#fff3e0',
+    iconBgDark: 'color-mix(in srgb, #f97316 15%, var(--vp-c-bg-soft))',
   },
 ]
 </script>
@@ -32,7 +41,11 @@ const entries = [
       <div class="gs-cards">
         <a v-for="e in entries" :key="e.key" :href="e.href" class="gs-card">
           <div class="gs-card-header">
-            <span class="gs-card-icon" v-html="e.icon" />
+            <div
+              class="gs-card-icon-wrap"
+              :style="{ '--icon-color': e.iconColor, '--icon-bg': e.iconBg, '--icon-bg-dark': e.iconBgDark }">
+              <span class="gs-card-icon" v-html="e.icon" />
+            </div>
             <h3 class="gs-card-title">{{ $t(`getStarted.${e.key}.title`) }}</h3>
           </div>
           <p class="gs-card-desc">{{ $t(`getStarted.${e.key}.desc`) }}</p>
@@ -113,41 +126,50 @@ const entries = [
   flex-direction: column;
   align-items: flex-start;
   padding: 1.25rem;
-  border-radius: 0.75rem;
-  border: 1px solid var(--vp-c-divider);
+  border-radius: var(--lb-card-radius);
+  border: 1px solid var(--lb-card-border);
   background: var(--vp-c-bg);
   text-decoration: none !important;
-  transition: all 0.25s;
+  transition: transform 0.25s, box-shadow 0.25s;
 }
 
 .gs-card:hover {
-  border-color: var(--brand-color);
-  box-shadow: 0 4px 20px color-mix(in srgb, var(--brand-color) 8%, transparent);
-  transform: translateY(-2px);
+  box-shadow: var(--lb-card-shadow-2);
+  transform: translateY(-3px);
 }
 
 .gs-card-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.75rem;
   margin-bottom: 0.75rem;
+}
+
+.gs-card-icon-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: var(--icon-bg);
+}
+
+:root.dark .gs-card-icon-wrap {
+  background: var(--icon-bg-dark);
 }
 
 .gs-card-icon {
   display: flex;
   flex-shrink: 0;
-  width: 1.25rem;
-  height: 1.25rem;
-  color: var(--vp-c-text-3);
-  transition: color 0.25s, transform 0.25s;
+  width: 20px;
+  height: 20px;
+  color: var(--icon-color);
 }
 .gs-card-icon :deep(svg) {
   width: 100%;
   height: 100%;
-}
-.gs-card:hover .gs-card-icon {
-  color: var(--brand-color);
-  transform: scale(1.15);
 }
 
 .gs-card-title {

--- a/docs/.vitepress/theme/components/NewHomePage/HeroSection.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/HeroSection.vue
@@ -3,7 +3,6 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import FlickeringGrid from '../inspira/FlickeringGrid.vue'
 import ColourfulText from '../inspira/ColourfulText.vue'
-import ShimmerButton from '../inspira/ShimmerButton.vue'
 
 const { t } = useI18n()
 
@@ -107,16 +106,8 @@ const ctaReadDocs = computed(() => t('hero.cta.readDocs'))
 
       <!-- CTA Buttons -->
       <div class="hero-cta">
-        <a href="https://open.longbridge.com/account" class="hero-link">
-          <ShimmerButton
-            :shimmer-color="'rgba(255,255,255,0.6)'"
-            shimmer-size="0.04em"
-            shimmer-duration="2.5s"
-            border-radius="100px"
-            :background="'var(--brand-100)'"
-            class="hero-btn-primary">
-            {{ ctaGetStarted }}
-          </ShimmerButton>
+        <a href="https://open.longbridge.com/account" class="hero-btn-primary">
+          {{ ctaGetStarted }}
         </a>
         <a href="/docs/" class="hero-cta-secondary">
           {{ ctaReadDocs }}
@@ -279,50 +270,51 @@ const ctaReadDocs = computed(() => t('hero.cta.readDocs'))
   gap: 1.25rem;
 }
 
-.hero-link {
-  text-decoration: none !important;
-}
-
 .hero-btn-primary {
-  padding: 0.7rem 2.25rem;
-  font-size: 1rem;
-  font-weight: 600;
-  color: #fff !important;
-  letter-spacing: 0.01em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--lb-btn-primary-h);
+  padding: 0 1.5rem;
+  font-size: var(--lb-btn-primary-fs);
+  font-weight: var(--lb-btn-primary-fw);
+  color: var(--lb-btn-primary-color) !important;
+  background: var(--lb-btn-primary-bg);
+  border-radius: var(--lb-btn-primary-radius);
+  text-decoration: none !important;
+  transition: opacity 0.2s;
 }
 
-:root.dark .hero-btn-primary {
-  color: #fff !important;
+.hero-btn-primary:hover {
+  opacity: 0.82;
 }
 
 .hero-cta-secondary {
   display: inline-flex;
   align-items: center;
+  height: var(--lb-btn-primary-h);
   gap: 0.375rem;
-  padding: 0.7rem 1.5rem;
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--brand-100);
+  padding: 0 1.25rem;
+  font-size: var(--lb-btn-primary-fs);
+  font-weight: 400;
+  color: var(--vp-c-text-1) !important;
+  background: var(--lb-btn-secondary-bg);
+  border-radius: var(--lb-btn-secondary-radius);
   text-decoration: none !important;
-  border-radius: 100px;
-  border: 1.5px solid color-mix(in srgb, var(--brand-100) 40%, transparent);
-  transition: gap 0.2s, border-color 0.2s, background 0.2s;
-  background: transparent;
+  border: none;
+  transition: background 0.2s, gap 0.2s;
 }
 
 .hero-cta-secondary:hover {
+  background: rgba(200, 200, 200, 0.8);
   gap: 0.625rem;
-  border-color: var(--brand-100);
-  background: color-mix(in srgb, var(--brand-100) 6%, transparent);
 }
 
 :root.dark .hero-cta-secondary {
-  color: var(--brand-80, var(--brand-100));
-  border-color: color-mix(in srgb, var(--brand-80, var(--brand-100)) 35%, transparent);
+  color: var(--lb-btn-secondary-color) !important;
 }
 
 :root.dark .hero-cta-secondary:hover {
-  border-color: var(--brand-80, var(--brand-100));
-  background: color-mix(in srgb, var(--brand-80, var(--brand-100)) 8%, transparent);
+  background: rgba(100, 100, 100, 0.6);
 }
 </style>

--- a/docs/.vitepress/theme/components/NewHomePage/ProductOpenAPI.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/ProductOpenAPI.vue
@@ -494,12 +494,11 @@ function copyInstall() {
 .sdk-cell {
   border-radius: 0.75rem;
   border: 1px solid var(--vp-c-divider);
-  background: radial-gradient(200px 120px at 100% 0%, color-mix(in srgb, var(--brand-color) 13%, transparent), transparent 70%), var(--vp-c-bg-soft);
+  background: radial-gradient(200px 120px at 100% 0%, color-mix(in srgb, var(--brand-color) 13%, transparent), transparent 70%), var(--vp-c-bg);
   padding: 1rem;
-  transition: border-color 0.2s, transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition: transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 .sdk-cell:not(.sdk-cell-hero):hover {
-  border-color: color-mix(in srgb, var(--brand-color) 40%, var(--vp-c-divider));
   transform: translateY(-2px);
   box-shadow: 0 8px 24px -6px rgba(10, 14, 25, 0.10);
 }

--- a/docs/.vitepress/theme/components/Pricing.vue
+++ b/docs/.vitepress/theme/components/Pricing.vue
@@ -260,7 +260,7 @@ const t = computed(() => {
         }">
         <div class="flex items-center justify-between mb-[18px]">
           <span
-            class="text-[0.68rem] font-semibold px-2 py-[2px] rounded-full whitespace-nowrap"
+            class="text-[12px] font-semibold px-2 py-1 rounded-full leading-none whitespace-nowrap"
             :style="{
               background: `color-mix(in srgb, ${LEVEL_COLORS.lv1.hex} 13%, transparent)`,
               color: LEVEL_COLORS.lv1.text,
@@ -330,7 +330,7 @@ const t = computed(() => {
         }">
         <div class="flex items-center justify-between mb-[18px]">
           <span
-            class="text-[0.68rem] font-semibold px-2 py-[2px] rounded-full whitespace-nowrap"
+            class="text-[12px] font-semibold px-2 py-1 rounded-full leading-none whitespace-nowrap"
             :style="{
               background: `color-mix(in srgb, ${LEVEL_COLORS.lv2.hex} 13%, transparent)`,
               color: LEVEL_COLORS.lv2.text,
@@ -413,7 +413,7 @@ const t = computed(() => {
         }">
         <div class="flex items-center justify-between mb-[18px]">
           <span
-            class="text-[0.68rem] font-semibold px-2 py-[2px] rounded-full whitespace-nowrap"
+            class="text-[12px] font-semibold px-2 py-1 rounded-full leading-none whitespace-nowrap"
             :style="{
               background: `color-mix(in srgb, ${LEVEL_COLORS.opra.hex} 13%, transparent)`,
               color: LEVEL_COLORS.opra.text,

--- a/docs/.vitepress/theme/components/Skill.vue
+++ b/docs/.vitepress/theme/components/Skill.vue
@@ -4175,7 +4175,7 @@ const currentExample = computed(() => {
 .skill-chat-window {
   flex: 1;
   background: var(--vp-c-bg);
-  border: 1px solid var(--vp-c-divider);
+  border: 1px solid var(--lb-card-border);
   border-radius: 10px;
   overflow-y: auto;
   display: flex;

--- a/docs/.vitepress/theme/components/Skill.vue
+++ b/docs/.vitepress/theme/components/Skill.vue
@@ -2467,6 +2467,7 @@ const currentExample = computed(() => {
   <!-- ─── Hero ──────────────────────────────────────────────────────────────── -->
   <div class="skill-hero border-b border-[var(--vp-c-divider)]">
     <div class="max-w-3xl mx-auto px-6 py-16 text-center">
+      <div class="skill-badge">{{ t.badge.value }}</div>
       <h1 class="skill-title">
         {{ t.heroTitle1.value }}
       </h1>
@@ -3791,12 +3792,13 @@ const currentExample = computed(() => {
 /* ─── Hero ───────────────────────────────────────────────────────────────── */
 .skill-badge {
   display: inline-block;
-  border: 1px solid var(--vp-c-brand-1);
-  border-radius: 20px;
-  padding: 3px 14px;
-  font-size: 0.75rem;
+  background: color-mix(in srgb, var(--vp-c-brand-1) 12%, transparent);
+  border-radius: var(--lb-badge-radius, 9999px);
+  padding: var(--lb-badge-py, 4px) var(--lb-badge-px, 8px);
+  font-size: var(--lb-badge-fs, 12px);
+  font-weight: var(--lb-badge-fw, 600);
+  line-height: var(--lb-badge-lh, 1);
   color: var(--vp-c-brand-1);
-  letter-spacing: 0.04em;
   margin-bottom: 20px;
 }
 .skill-title {

--- a/docs/.vitepress/theme/layouts/LayoutInner.vue
+++ b/docs/.vitepress/theme/layouts/LayoutInner.vue
@@ -58,7 +58,7 @@ provide('hero-image-slot-exists', heroImageSlotExists)
       <template #page-top><slot name="page-top" /></template>
       <template #page-bottom>
         <slot name="page-bottom" />
-        <div class="max-w-[1200px] mx-auto px-8">
+        <div v-if="frontmatter.pageClass !== 'new-home-page'" class="max-w-[1200px] mx-auto">
           <Footer />
         </div>
       </template>

--- a/docs/.vitepress/theme/style/css-var.scss
+++ b/docs/.vitepress/theme/style/css-var.scss
@@ -289,5 +289,5 @@
   --lb-btn-primary-color: #000000;
   --lb-btn-secondary-bg: rgba(80, 80, 80, 0.5);
   --lb-btn-secondary-color: #d1d5db;
-  --lb-card-border: #374151;
+  --lb-card-border: rgba(255, 255, 255, 0.1);
 }

--- a/docs/.vitepress/theme/style/css-var.scss
+++ b/docs/.vitepress/theme/style/css-var.scss
@@ -129,6 +129,27 @@
   --home-bg-color: #f8f9fa;
   --home-text-color: #000000;
   --home-bg-color-1: #ffffff;
+
+  /* LB design tokens */
+  --lb-btn-primary-bg: #000000;
+  --lb-btn-primary-color: #ffffff;
+  --lb-btn-primary-radius: 9999px;
+  --lb-btn-primary-h: 36px;
+  --lb-btn-primary-fs: 14px;
+  --lb-btn-primary-fw: 500;
+  --lb-btn-secondary-bg: rgba(210, 210, 210, 0.6);
+  --lb-btn-secondary-color: #374151;
+  --lb-btn-secondary-radius: 30px;
+  --lb-card-border: #e5e7eb;
+  --lb-card-radius: 12px;
+  --lb-card-shadow-1: rgba(0, 0, 0, 0.04) 0px 2px 8px;
+  --lb-card-shadow-2: rgba(0, 0, 0, 0.09) 0px 8px 24px;
+  --lb-badge-fs: 12px;
+  --lb-badge-fw: 600;
+  --lb-badge-lh: 1;
+  --lb-badge-py: 4px;
+  --lb-badge-px: 8px;
+  --lb-badge-radius: 9999px;
 }
 
 .dark {
@@ -262,4 +283,11 @@
   --home-bg-color: #161618;
   --home-text-color: #ffffff;
   --home-bg-color-1: #1b1b1f;
+
+  /* LB design tokens (dark overrides) */
+  --lb-btn-primary-bg: #ffffff;
+  --lb-btn-primary-color: #000000;
+  --lb-btn-secondary-bg: rgba(80, 80, 80, 0.5);
+  --lb-btn-secondary-color: #d1d5db;
+  --lb-card-border: #374151;
 }

--- a/docs/.vitepress/theme/style/custom.scss
+++ b/docs/.vitepress/theme/style/custom.scss
@@ -83,3 +83,8 @@
 .DocSearch-Button {
   border-radius: 20px !important;
 }
+
+.VPNavBarTitle .logo {
+  width: 145px !important;
+  height: auto !important;
+}

--- a/specs/2026-05-14-design-redesign.md
+++ b/specs/2026-05-14-design-redesign.md
@@ -1,0 +1,272 @@
+# Design Redesign Spec — 2026-05-14
+
+## 目标
+
+按 DESIGN.md 规范对首页（Homepage）、Skill 页、Pricing 页进行设计优化，建立 `--lb-*` CSS 变量层，统一按钮、卡片、徽标、section 背景节奏，同时保留产品卡片和数据层级的多色系统。
+
+**范围约定：**
+- 字体保持 Inter，不引入 Cera Pro / Geist
+- Light / Dark 双模式全部适配
+- 多色保留：CoreFeatures 产品卡片、Skill 场景卡片、Pricing 数据权限 badge 各自保留差异色
+- 结构型元素（按钮、Hero 背景、section 背景、卡片边框、阴影）按 DESIGN.md 统一
+
+---
+
+## 1. CSS 变量层（`css-var.scss`）
+
+在现有 `:root` / `.dark` 块末尾追加 `--lb-*` token，不删改现有变量。
+
+### 1.1 按钮 token
+
+```scss
+/* Primary Button */
+--lb-btn-primary-bg:        #000000;
+--lb-btn-primary-bg-dark:   #ffffff;
+--lb-btn-primary-text:      #ffffff;
+--lb-btn-primary-text-dark: #000000;
+--lb-btn-primary-radius:    9999px;
+--lb-btn-primary-h:         36px;
+--lb-btn-primary-px:        20px;
+--lb-btn-primary-fs:        14px;
+--lb-btn-primary-fw:        500;
+
+/* Secondary Button */
+--lb-btn-secondary-bg:        rgba(210, 210, 210, 0.6);
+--lb-btn-secondary-bg-dark:   rgba(255, 255, 255, 0.10);
+--lb-btn-secondary-text:      #0f1729;
+--lb-btn-secondary-text-dark: rgba(255, 255, 255, 0.85);
+--lb-btn-secondary-border:    rgba(0, 0, 0, 0.10);
+--lb-btn-secondary-border-dark: rgba(255, 255, 255, 0.15);
+--lb-btn-secondary-radius:    30px;
+--lb-btn-secondary-h:         36px;
+```
+
+### 1.2 卡片 token
+
+```scss
+--lb-card-bg:         #ffffff;
+--lb-card-border:     #e5e7eb;
+--lb-card-radius:     12px;
+--lb-card-shadow-1:   rgba(0,0,0,0.04) 0px 2px 8px;   /* static */
+--lb-card-shadow-2:   rgba(0,0,0,0.09) 0px 8px 24px;  /* hover */
+--lb-card-bg-dark:    rgba(255,255,255,0.04);
+--lb-card-border-dark: rgba(255,255,255,0.09);
+```
+
+### 1.3 Badge token
+
+```scss
+--lb-badge-fs:      12px;
+--lb-badge-fw:      600;
+--lb-badge-lh:      1;
+--lb-badge-px:      8px;
+--lb-badge-py:      4px;
+--lb-badge-radius:  9999px;
+```
+
+### 1.4 Section 背景 token
+
+```scss
+--lb-section-bg:    var(--vp-c-bg);       /* #ffffff / dark equiv */
+--lb-section-bg-alt: var(--vp-c-bg-soft); /* #f8f9fa / dark equiv */
+```
+
+---
+
+## 2. 首页 Hero（`HeroSection.vue`）
+
+### 2.1 主按钮（替换 ShimmerButton）
+
+| 属性 | 值 |
+|------|-----|
+| background | `var(--lb-btn-primary-bg)` — `#000` |
+| color | `#ffffff` |
+| border-radius | `9999px` |
+| height | `36px` |
+| padding | `10px 20px` |
+| font-size | `14px` |
+| font-weight | `500` |
+| box-shadow | `rgba(0,0,0,0.07) 0px 4px 16px` |
+| hover | opacity `0.85`，shadow 加深 |
+| dark | background `#ffffff`，color `#000` |
+
+移除 `ShimmerButton` 组件及 `shimmer-*` props，改为原生 `<a>` + 直接样式。
+
+### 2.2 次按钮（替换青色边框）
+
+| 属性 | 值 |
+|------|-----|
+| background | `rgba(210,210,210,0.6)` |
+| color | `#0f1729` |
+| border | `1px solid rgba(0,0,0,0.1)` |
+| border-radius | `30px` |
+| height | `36px` |
+| font-size | `14px` |
+| hover | background `rgba(210,210,210,0.8)` |
+| dark | background `rgba(255,255,255,0.10)`，color `rgba(255,255,255,0.85)` |
+
+移除 `.hero-cta-secondary` 的 `var(--brand-100)` 颜色和 `border-color` 逻辑。
+
+---
+
+## 3. 快速开始（`GetStarted.vue`）
+
+### 3.1 图标容器
+
+每张卡片顶部新增 40×40px icon wrap：
+
+```css
+.gs-card-icon-wrap {
+  width: 40px; height: 40px;
+  border-radius: 10px;
+  display: flex; align-items: center; justify-content: center;
+}
+```
+
+三张卡片分别对应颜色：
+
+| 卡片 | icon-wrap bg | icon color |
+|------|-------------|------------|
+| 认证（auth） | `rgba(0,184,184,0.10)` | `#00b8b8` |
+| API Reference | `rgba(42,153,254,0.10)` | `#2a99fe` |
+| CLI 指南 | `rgba(252,82,0,0.10)` | `#fc5200` |
+
+Dark 下：透明度略高（`0.12`），颜色维持。
+
+### 3.2 卡片 hover
+
+**只做阴影加深 + 上浮，不改变边框颜色：**
+
+```css
+.gs-card:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--lb-card-shadow-2);
+  /* border-color 不变，保持 #e5e7eb */
+}
+```
+
+### 3.3 描述文字
+
+`.gs-card-desc` 颜色从 `var(--vp-c-text-3)` 改为 `var(--vp-c-text-2)`（提高可读性）。
+
+### 3.4 链接文字
+
+`.gs-card-link` 始终可见（灰色 `var(--vp-c-text-3)`），hover → `var(--brand-color)`，移除 `align-self: flex-end`，改为在 card 内部底部自然排列。
+
+---
+
+## 4. Pricing 页（`Pricing.vue`）
+
+### 4.1 产品卡片边框
+
+所有三张 tier 卡片统一使用 `border: 1px solid var(--lb-card-border)`（`#E5E7EB`），移除现有 HK LV2 / OPRA 的蓝色 border-color 覆盖逻辑。
+
+### 4.2 Badge 规范
+
+Tier badge 使用 LEVEL_COLORS（来自 `QuotePermissionData.ts`），不改变颜色数据，只统一 badge 形状：
+
+```css
+.tier-badge {
+  display: inline-flex; align-items: center;
+  font-size: var(--lb-badge-fs);       /* 12px */
+  font-weight: var(--lb-badge-fw);     /* 600 */
+  line-height: var(--lb-badge-lh);     /* 1 */
+  padding: var(--lb-badge-py) var(--lb-badge-px); /* 4px 8px */
+  border-radius: var(--lb-badge-radius); /* 9999px */
+}
+```
+
+颜色取值规则（按 LEVEL_COLORS 原始值）：
+
+| Tier | bg | color | border |
+|------|-----|-------|--------|
+| lv1（US） | `rgba(59,130,246,0.10)` | `#2563eb` | `#3b82f6` |
+| lv2（HK） | `rgba(249,115,22,0.10)` | `#ea580c` | `#f97316` |
+| opra | `rgba(168,85,247,0.10)` | `#9333ea` | `#a855f7` |
+
+### 4.3 卡片 hover
+
+```css
+.pricing-card:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--lb-card-shadow-2);
+  /* border 不变 */
+}
+```
+
+---
+
+## 5. Section 背景节奏（首页）
+
+各 section 奇偶交替，以 `var(--lb-section-bg)` / `var(--lb-section-bg-alt)` 区分：
+
+| Section | bg token |
+|---------|---------|
+| Hero | `--lb-section-bg`（白） |
+| PlatformStats | `--lb-section-bg-alt`（#F8F9FA） |
+| ArchSection | `--lb-section-bg` |
+| CoreFeatures | `--lb-section-bg-alt` |
+| Product CLI/Skill/MCP/OpenAPI | `--lb-section-bg` |
+| CapSection | `--lb-section-bg-alt` |
+| GetStarted | `--lb-section-bg-alt` |
+
+Dark 下 `--vp-c-bg` / `--vp-c-bg-soft` 已有适当对应，无需新增 dark 变量。
+
+---
+
+## 6. Skill 页 Hero（`Skill.vue`）
+
+### 6.1 顶部 Badge
+
+在 `.skill-hero` 内容顶部新增 badge，位于 `.skill-title` 之前：
+
+```html
+<div class="skill-hero-badge">Longbridge Developers · Skill</div>
+```
+
+```css
+.skill-hero-badge {
+  display: inline-flex; align-items: center;
+  font-size: 12px; font-weight: 600; line-height: 1;
+  padding: 4px 10px; border-radius: 9999px;
+  border: 1px solid var(--brand-color);
+  background: color-mix(in srgb, var(--brand-color) 8%, transparent);
+  color: var(--brand-color);
+  margin-bottom: 20px;
+}
+```
+
+### 6.2 cmd block
+
+`.skill-cmd-block--prominent` 背景 / 边框对齐 Standard Card：
+
+```css
+background: var(--lb-section-bg-alt);
+border: 1px solid var(--lb-card-border);
+border-radius: 10px;
+```
+
+---
+
+## 7. 不改动项
+
+以下内容明确保留，不纳入本次改动范围：
+
+- `CoreFeaturesSection.vue` 产品卡片的 per-product accent 色（skill/cli/mcp/sdk/paper/llm）
+- `Skill.vue` 场景卡片的 per-scenario 色（monitor/research/trade/chart/portfolio/coding）
+- `HeroSection.vue` FlickeringGrid 背景动效和 ColourfulText 动态产品名
+- `font.css` Inter 字体加载，不修改
+- 首页整体布局结构和 section 内容
+
+---
+
+## 涉及文件
+
+| 文件 | 改动类型 |
+|------|---------|
+| `docs/.vitepress/theme/style/css-var.scss` | 追加 `--lb-*` token |
+| `docs/.vitepress/theme/components/NewHomePage/HeroSection.vue` | 按钮替换 |
+| `docs/.vitepress/theme/components/NewHomePage/GetStarted.vue` | 图标、hover、文字 |
+| `docs/.vitepress/theme/components/NewHomePage/*.vue`（各 section） | bg token 规范化 |
+| `docs/.vitepress/theme/components/Pricing.vue` | badge 形状、卡片 border |
+| `docs/.vitepress/theme/components/Skill.vue` | Hero badge、cmd block |


### PR DESCRIPTION
## Summary

- 替换导航栏 Logo 为新版 Longbridge Developers 图片（亮/暗双套），隐藏站点文字标题，CSS 固定宽度 145px
- 去除首页 OpenAPI SDK bento 卡片灰色背景（`bg-soft` → `bg`），移除 hover 时 border 变色
- 修复首页双 Footer 问题：`LayoutInner` page-bottom 插槽对 `new-home-page` 做条件判断
- 首页 `NewHomePage/Footer` 底部 padding 增至 2.5rem；doc 页 `HomePage/Footer` 减少顶部 margin 并增加底部空白
- `skill-chat-window` border 改用 `--lb-card-border` token；暗色模式值调整为 `rgba(255,255,255,0.1)`
- 去掉 `LayoutInner` Footer 容器多余的 `px-8`

## Test plan

- [ ] 首页：Logo 正常显示（亮/暗），无站点标题文字，宽度 145px
- [ ] 首页：SDK 卡片背景为白色，hover 无 border 变色
- [ ] 首页：页脚只有一个 Footer，底部有足够留白
- [ ] Pricing 页：Footer 底部空白正常
- [ ] Skill 页：chat window border 清晰，暗色模式不过亮
- [ ] 暗色模式全面检查

🤖 Generated with [Claude Code](https://claude.com/claude-code)