### PR TITLE
fix(cli): collapse all sidebar groups by default

### DIFF
--- a/docs/en/docs/cli/market-data/_category_.json
+++ b/docs/en/docs/cli/market-data/_category_.json
@@ -1,1 +1,1 @@
-{ "label": "Market Data", "icon": "bar-chart-2", "position": 3, "collapsed": false }
+{ "label": "Market Data", "icon": "bar-chart-2", "position": 3, "collapsed": true }

--- a/docs/en/docs/cli/quant/_category_.json
+++ b/docs/en/docs/cli/quant/_category_.json
@@ -1,1 +1,1 @@
-{ "label": "Quant", "icon": "line-chart", "position": 9, "collapsed": false }
+{ "label": "Quant", "icon": "line-chart", "position": 9, "collapsed": true }

--- a/docs/zh-CN/docs/cli/market-data/_category_.json
+++ b/docs/zh-CN/docs/cli/market-data/_category_.json
@@ -1,1 +1,1 @@
-{ "label": "行情数据", "icon": "bar-chart-2", "position": 3, "collapsed": false }
+{ "label": "行情数据", "icon": "bar-chart-2", "position": 3, "collapsed": true }

--- a/docs/zh-CN/docs/cli/quant/_category_.json
+++ b/docs/zh-CN/docs/cli/quant/_category_.json
@@ -1,1 +1,1 @@
-{ "label": "量化", "icon": "line-chart", "position": 9, "collapsed": false }
+{ "label": "量化", "icon": "line-chart", "position": 9, "collapsed": true }

--- a/docs/zh-HK/docs/cli/market-data/_category_.json
+++ b/docs/zh-HK/docs/cli/market-data/_category_.json
@@ -1,1 +1,1 @@
-{ "label": "行情數據", "icon": "bar-chart-2", "position": 3, "collapsed": false }
+{ "label": "行情數據", "icon": "bar-chart-2", "position": 3, "collapsed": true }

--- a/docs/zh-HK/docs/cli/quant/_category_.json
+++ b/docs/zh-HK/docs/cli/quant/_category_.json
@@ -1,1 +1,1 @@
-{ "label": "量化", "icon": "line-chart", "position": 9, "collapsed": false }
+{ "label": "量化", "icon": "line-chart", "position": 9, "collapsed": true }


### PR DESCRIPTION
## Summary

- CLI docs sidebar 的 `market-data` 和 `quant` 分组之前未设置折叠，导致与其他分组不一致
- 将三个语言版本（en / zh-CN / zh-HK）的这两个分组统一改为 `collapsed: true`，使 CLI sidebar 所有分组默认折叠

## Test plan

- [ ] 访问 CLI 文档页面，确认所有 sidebar 分组默认均为折叠状态

🤖 Generated with [Claude Code](https://claude.com/claude-code)