### PR TITLE
docs(changelog): CLI v0.21.0 

### DIFF
--- a/docs/en/docs/changelog.md
+++ b/docs/en/docs/changelog.md
@@ -6,6 +6,17 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-05-15
+
+### CLI v0.21.0
+
+- **`industry-rank`** — industry ranking by market (US/HK/CN/SG); pairs with `industry-peers` to explore the full competitive tree for any sector
+- **`industry-peers`** — sub-sector tree showing stock count, daily change, and YTD change per node
+- **`business-segments`** — revenue breakdown by business segment, current period or historical trend
+- **`financial-report snapshot`** — AI-generated earnings summary with beat/miss analysis vs consensus estimates
+- **`institution-rating --views`** — month-by-month buy/hold/sell distribution to track how analyst sentiment shifts over time
+- MCP server updated with the same new capabilities (133 tools total)
+
 ## 2026-05-13
 
 ### SDK v4.1.0

--- a/docs/zh-CN/docs/changelog.md
+++ b/docs/zh-CN/docs/changelog.md
@@ -6,6 +6,17 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-05-15
+
+### CLI v0.21.0
+
+- **`industry-rank`** — 按市场（US/HK/CN/SG）查看行业强弱排名；配合 `industry-peers` 展开任意板块的完整竞争格局
+- **`industry-peers`** — 行业子板块树形结构，展示各节点的股票数、当日涨跌和年初至今涨跌
+- **`business-segments`** — 按业务分部拆解营收，支持当期数据或历史趋势对比
+- **`financial-report snapshot`** — AI 生成财报摘要，含营收、EBIT、净利润相对分析师预期的差距分析
+- **`institution-rating --views`** — 逐月展示机构评级分布（买入/持有/卖出）的变化趋势
+- MCP 服务同步新增相同功能（工具总数达 133 个）
+
 ## 2026-05-13
 
 ### SDK v4.1.0

--- a/docs/zh-HK/docs/changelog.md
+++ b/docs/zh-HK/docs/changelog.md
@@ -6,6 +6,17 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-05-15
+
+### CLI v0.21.0
+
+- **`industry-rank`** — 按市場（US/HK/CN/SG）查看行業強弱排名；配合 `industry-peers` 展開任意板塊的完整競爭格局
+- **`industry-peers`** — 行業子板塊樹形結構，展示各節點的股票數、當日漲跌和年初至今漲跌
+- **`business-segments`** — 按業務分部拆解營收，支援當期數據或歷史趨勢對比
+- **`financial-report snapshot`** — AI 生成財報摘要，含營收、EBIT、淨利潤相對分析師預期的差距分析
+- **`institution-rating --views`** — 逐月展示機構評級分佈（買入/持有/賣出）的變化趨勢
+- MCP 服務同步新增相同功能（工具總數達 133 個）
+
 ## 2026-05-13
 
 ### SDK v4.1.0


### PR DESCRIPTION
## Summary

Adds changelog entry for CLI v0.21.0 (consolidating v0.20.1~v0.20.3), with MCP v0.3.0 mentioned inline.

### CLI v0.21.0
- Industry Intelligence: `industry-rank`, `industry-peers`
- Revenue Segment Breakdown: `business-segments`
- AI Earnings Snapshot: `financial-report snapshot`
- Analyst Conviction Trends: `institution-rating --views`
- MCP server updated with the same capabilities (133 tools total)

Written for end users — less technical, more about what you can now do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)