### PR TITLE
fix(nav): use createLoginRedirectPath for login button, fix footer legal links

### DIFF
--- a/docs/.vitepress/theme/components/AppFooter.vue
+++ b/docs/.vitepress/theme/components/AppFooter.vue
@@ -1,8 +1,13 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { localePath, getBasenameLocale } from '../utils/i18n'
 import { useI18n } from 'vue-i18n'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
+
+const sgBaseUrl = computed(() =>
+  locale.value === 'en' ? 'https://longbridge.com/sg' : 'https://longbridge.com/sg/zh-CN',
+)
 
 function switchLocale(locale: string) {
   if (typeof window === 'undefined') return
@@ -81,9 +86,9 @@ const year = new Date().getFullYear()
       <div>
         <h5>{{ t('footer.legal') }}</h5>
         <ul>
-          <li><a href="#">{{ t('footer.terms') }}</a></li>
-          <li><a href="#">{{ t('footer.privacy') }}</a></li>
-          <li><a href="#">{{ t('footer.risk') }}</a></li>
+          <li><a :href="`${sgBaseUrl}/support/topics/us-trade/user-agreement`" target="_blank" rel="noreferrer">{{ t('footer.terms') }}</a></li>
+          <li><a :href="`${sgBaseUrl}/support/topics/Other/privacy-policy`" target="_blank" rel="noreferrer">{{ t('footer.privacy') }}</a></li>
+          <li><a :href="`${sgBaseUrl}/support/topics/Other/risk-disclosure`" target="_blank" rel="noreferrer">{{ t('footer.risk') }}</a></li>
         </ul>
       </div>
     </div>

--- a/docs/.vitepress/theme/components/AppNav.vue
+++ b/docs/.vitepress/theme/components/AppNav.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted, onUnmounted, defineAsyncComponent } from 'vue
 import { useData, useRoute } from 'vitepress'
 import { useI18n } from 'vue-i18n'
 import { localePath, getBasenameLocale } from '../utils/i18n'
+import { createLoginRedirectPath } from '../utils/navigate'
 import { isLoginState, initLoginState } from '../composables/useLoginState'
 import { useAvatar } from './UserAvatar/uesAvatar'
 import UserAvatarIcon from './UserAvatar/UserAvatarIcon.vue'
@@ -77,6 +78,7 @@ function toggleTheme(_e: MouseEvent) {
 
 // Login / avatar
 const isLogin = isLoginState
+const loginUrl = computed(() => createLoginRedirectPath())
 const { avatar } = useAvatar()
 const avatarOpen = ref(false)
 const avatarEl = ref<HTMLElement>()
@@ -273,7 +275,7 @@ onUnmounted(() => {
             </div>
           </template>
           <!-- Not logged in: Get Started -->
-          <a v-else class="btn btn-primary btn-sm" :href="localePath('/login')">
+          <a v-else class="btn btn-primary btn-sm" target="_self" :href="loginUrl">
             {{ t('nav.getStarted') }}
             <svg
               width="13"


### PR DESCRIPTION
## Summary

- **AppNav**: Replace `localePath('/login')` with `createLoginRedirectPath()` + `target="_self"` on the Get Started button — bypasses VitePress SPA router interception so the browser navigates to the server-side `/login` route with proper `redirect_to` params
- **AppFooter**: Replace placeholder `href="#"` on Terms / Privacy / Risk Disclosure links with real Longbridge URLs, using locale-aware `sgBaseUrl`

## Test plan

- [ ] Click "Get Started" in navbar → should navigate to login page (not VitePress 404)
- [ ] After login, should redirect back to the originating page
- [ ] Footer legal links open correct Longbridge support pages in new tab
- [ ] Locale switching (zh-CN / zh-HK) uses correct sgBaseUrl prefix for footer links

🤖 Generated with [Claude Code](https://claude.com/claude-code)