### PR TITLE
feat: add User Data Authorisation docs and footer links

### DIFF
--- a/docs/.vitepress/theme/components/AppFooter.vue
+++ b/docs/.vitepress/theme/components/AppFooter.vue
@@ -121,11 +121,6 @@ const year = new Date().getFullYear()
             }}</a>
           </li>
           <li>
-            <a :href="`${sgBaseUrl}/support/topics/Other/risk-disclosure`" target="_blank" rel="noreferrer">{{
-              t('footer.risk')
-            }}</a>
-          </li>
-          <li>
             <a :href="localePath('/docs/legal/user-data-authorization-hk')">{{ t('footer.dataAuthorisationHK') }}</a>
           </li>
           <li>

--- a/docs/.vitepress/theme/components/AppFooter.vue
+++ b/docs/.vitepress/theme/components/AppFooter.vue
@@ -125,6 +125,12 @@ const year = new Date().getFullYear()
               t('footer.risk')
             }}</a>
           </li>
+          <li>
+            <a :href="localePath('/docs/legal/user-data-authorization-hk')">{{ t('footer.dataAuthorisationHK') }}</a>
+          </li>
+          <li>
+            <a :href="localePath('/docs/legal/user-data-authorization-sg')">{{ t('footer.dataAuthorisationSG') }}</a>
+          </li>
         </ul>
       </div>
     </div>

--- a/docs/.vitepress/theme/locales/en.json
+++ b/docs/.vitepress/theme/locales/en.json
@@ -84,7 +84,6 @@
   "footer.feedback": "Feedback",
   "footer.terms": "Terms of Service",
   "footer.privacy": "Privacy Policy",
-  "footer.risk": "Risk Disclosure",
   "footer.dataAuthorisationHK": "Data Authorisation (HK)",
   "footer.dataAuthorisationSG": "Data Authorisation (SG)",
   "footer.download": "Download",

--- a/docs/.vitepress/theme/locales/en.json
+++ b/docs/.vitepress/theme/locales/en.json
@@ -85,6 +85,8 @@
   "footer.terms": "Terms of Service",
   "footer.privacy": "Privacy Policy",
   "footer.risk": "Risk Disclosure",
+  "footer.dataAuthorisationHK": "Data Authorisation (HK)",
+  "footer.dataAuthorisationSG": "Data Authorisation (SG)",
   "footer.download": "Download",
   "footer.statusPage": "Status",
   "footer.about": "About",

--- a/docs/.vitepress/theme/locales/zh-CN.json
+++ b/docs/.vitepress/theme/locales/zh-CN.json
@@ -84,7 +84,6 @@
   "footer.feedback": "意见反馈",
   "footer.terms": "服务条款",
   "footer.privacy": "隐私政策",
-  "footer.risk": "风险披露",
   "footer.dataAuthorisationHK": "数据授权确认（香港）",
   "footer.dataAuthorisationSG": "数据授权确认（新加坡）",
   "footer.download": "下载应用",

--- a/docs/.vitepress/theme/locales/zh-CN.json
+++ b/docs/.vitepress/theme/locales/zh-CN.json
@@ -85,6 +85,8 @@
   "footer.terms": "服务条款",
   "footer.privacy": "隐私政策",
   "footer.risk": "风险披露",
+  "footer.dataAuthorisationHK": "数据授权确认（香港）",
+  "footer.dataAuthorisationSG": "数据授权确认（新加坡）",
   "footer.download": "下载应用",
   "footer.statusPage": "服务状态",
   "footer.about": "关于我们",

--- a/docs/.vitepress/theme/locales/zh-HK.json
+++ b/docs/.vitepress/theme/locales/zh-HK.json
@@ -84,7 +84,6 @@
   "footer.feedback": "意見反饋",
   "footer.terms": "服務條款",
   "footer.privacy": "隱私政策",
-  "footer.risk": "風險披露",
   "footer.dataAuthorisationHK": "數據授權確認（香港）",
   "footer.dataAuthorisationSG": "數據授權確認（新加坡）",
   "footer.download": "下載應用",

--- a/docs/.vitepress/theme/locales/zh-HK.json
+++ b/docs/.vitepress/theme/locales/zh-HK.json
@@ -85,6 +85,8 @@
   "footer.terms": "服務條款",
   "footer.privacy": "隱私政策",
   "footer.risk": "風險披露",
+  "footer.dataAuthorisationHK": "數據授權確認（香港）",
+  "footer.dataAuthorisationSG": "數據授權確認（新加坡）",
   "footer.download": "下載應用",
   "footer.statusPage": "服務狀態",
   "footer.about": "關於我們",

--- a/docs/en/docs/legal/_category_.json
+++ b/docs/en/docs/legal/_category_.json
@@ -1,0 +1,8 @@
+{
+  "position": 8,
+  "label": "Legal",
+  "collapsible": true,
+  "collapsed": true,
+  "link": null,
+  "icon": "book"
+}

--- a/docs/en/docs/legal/user-data-authorization-hk.md
+++ b/docs/en/docs/legal/user-data-authorization-hk.md
@@ -1,0 +1,111 @@
+---
+title: 'User Data Authorisation and Acknowledgement — HK'
+sidebar_label: 'Data Authorisation (HK)'
+id: legal_user-data-authorization-hk
+slug: '/legal/user-data-authorization-hk'
+sidebar_position: 1
+---
+
+Please read this Authorisation carefully before proceeding. **By completing and submitting this Authorisation, you acknowldge and confirm that you have read, understood, and agree to be bound by all terms set out below in connection with the Longbridge Developers.**
+
+**1. Background**
+
+Longbridge AI Technologies Limited and its relevant affiliates (collectivly, "**Longbridge**") provides programmatic interfaces through which market data, account functionalities, and related services are encapsulated and made available to users in the form of Command-Line Interface tools, Model Context Protocol integrations, and other developer tools and services (collectively, "**Longbridge Developers**").
+
+Users may access and invoke the relevant interfaces based on their own needs and integrate them with third-party AI terminals or applications selected by the users (including, without limitation, OpenClaw, Claude Code, Cursor, and similar tools). Upon installation and successful connection, users may interact with the Longbridge Platform and/or their platform or securities accounts (where applicable) through such third-party terminals or applications.
+
+This Authorisation governs: (a) the sharing of your selected account data among the relevant Longbridge group entities and with relevant third-party AI terminal operators as you selected ("**Third-Party AI Terminals**"); and (b) the terms on which instructions you issue through Third-Party AI Terminals are treated as your own instructions for the purpose of executing securities transactions.
+
+**2. Data Sharing Authorisation and Purpose of Sharing**
+
+**2.1 Authorised Data Scope**
+
+The categories of data covered by this Authorisation are displayed below and/or under "Quotes Permission" section on the OAuth authorisation page, and are subject to your selection. Unless otherwise specified, data related to securities trading will generally be shared by Long Bridge HK Limited ("**Longbridge Securities**"), while other data will be shared by Longbridge Platform (as defined in the terms and conditions of Longbridge Platform). The data categories authorised by you will be shared by Longbridge with Third-Party AI Terminals solely for the purpose of enabling the function of the Longbridge Developers described herein.
+
+The data categories that may be available include the following, with access granted on a feature-by-feature basis depending on the functionality selected on the relevant page:
+
+1. Watchlist --- Manage user watchlists (list / create / update / delete) and retrieve the securities contained in a specific watchlist for display and maintenance.
+
+2. Trade Execution --- Buy, sell or any other operations about trade execution.
+
+3. Trade Order Lookup --- Cover the post-order-placement order lifecycle and execution capabilities, including order details and same-day / historical order queries, as well as same-day / historical trade report queries, and provide an estimate of the maximum purchasable quantity before placing an order.
+
+4. News & Filings --- Get the stock news.
+
+5. Account & Positions --- Provides read access to account asset and cash information, including fund holdings, stock holdings, account cash balance, and cash flow history for portfolio overview, position display, and reconciliation analysis.
+
+6. Market Sentiment --- Query "Market Temperature" (a fear-gauge-like sentiment thermometer) across equity markets, including current and historical readings for sentiment measurement, trend visualization, and comparative analysis.
+
+Any other data categories that may be made available from time to time.
+
+**2.2 Further Sharing with Third-Party AI Terminals**
+
+By granting authorization hereunder, you acknowledge and agree that the authorisation you hereby grant to Longbridge may, to the extent necessary to fulfil the purposes of Longbridge Developers, be further shared with Third-Party Terminals.
+
+**2.3 Purpose of Sharing**
+
+The data shared pursuant to your selections above will be used exclusively to enable the functionality of the Longbridge Developers. No data will be shared for any other purpose without your separate consent.
+
+**2.4 Data Protection and Compliance**
+
+All data collection, storage, and processing activities are conducted in accordance with the Personal Data (Privacy) Ordinance ("**PDPO**") and other applicable data protection regulations. Longbridge will only retain your data for as long as is necessary to fulfil the purposes set out in this Authorisation, or as required by applicable law. You have the right to withdraw your consent, access your data, and request correction of inaccurate data, in each case in accordance with the PDPO. You may withdraw this Authorisation at any time by updating your settings within the Longbridge platform. Withdrawal will take effect prospectively and will not affect instructions already submitted or executed prior to the effective date of withdrawal.
+
+**3. Instructions Transmitted via Third-Party AI Terminals**
+
+**3.1 Nature and Effect of Instructions via Third-Party AI Terminals(when applicable)**
+
+You acknowledge and agree that when you issue instructions through Third-Party AI Terminals, which instructions shall be transmitted to and executed by Longbridge Securities:
+
+Longbridge acts solely as the developer of the Longbridge Developers. Longbridge and Longbridge Securities do not control, review, endorse, or assume any responsibility or liability for the content, instructions, recommendations, or outputs generated by any Third-Party AI Terminal, including any trading decisions or outcomes arising therefrom. The Third-Party AI Terminal with which you interact is the responsible party for the AI services provided to you and you remain solely responsible for independently evaluating and verifying any information or recommendations provided by Third-Party AI Terminal before taking any action.
+
+The Third-Party AI Terminal transmits instructions on your behalf to Longbridge Securities for execution, but does not itself initiate, modify, interpret, or exercise any discretion over any instruction. Each instruction transmitted via Third-Party AI Terminal must be initiated by you through an explicit and deliberate user action. No instruction will be automatically generated, triggered, or executed without your input and confirmation.
+
+No Third-Party AI Terminal has constituted/ currently constitutes /will constitute an agent, representative, investment adviser, or decision-making entity of any Longbridge group entity or of you personally.
+
+Longbridge Securities executes instructions strictly in accordance with your authorisation, on an execution-only basis, without providing investment advice or exercising discretion.
+
+**By granting this Authorisation, you expressly permit the Third-Party AI Terminal you deploy to submit order instructions to Longbridge Securities on your behalf. Such instructions, once confirmed and transmitted, shall be treated as your own instructions to Longbridge Securities and shall be binding upon execution. Each instruction originates from, and is solely attributable to, you as the account holder. You agree that Longbridge Securities is entitled to act on such instructions without further verification of your identity beyond the authentication carried out at login.**
+
+**4. Risk Acknowledgement**
+
+You acknowledge and accept the following risks:
+
+The value of investments may rise or fall and past performance is not indicative of future results.
+
+Instructions transmitted via Third-Party AI Terminal on behalf of you to Longbridge are binding upon execution. Longbridge shall not be liable for any losses arising from instructions that you authorise, including instructions transmitted through any Third-Party AI Terminal.
+
+You are solely responsible for reviewing and verifying the accuracy of all instructions before they are submitted, regardless of the interface used.
+
+Third-Party AI Terminal may make errors in understanding or transmitting instructions. You should always confirm the details of any instruction before authorising it.
+
+Third-Party AI Terminal, as the entities responsible for AI terminal services, are obligated to comply with the PDPO and all other applicable Hong Kong laws in connection with the collection and processing of your data. You acknowledge that Longbridge does not control Third-Party AI Terminal's data practices and that you should review the privacy policies of any third-party AI terminal before use.
+
+**5. Risk Warning --- Connecting Your Securities Account**
+
+Linking your brokerage or securities account to Third-Party Terminal grants the AI the ability to access account data and, depending on permissions, to place, modify, or cancel orders on your behalf. **This may result in partial or total loss of your assets.** By enabling this connection, you acknowledge and accept the following risks:
+
+**AI errors.** Third-Party Terminal may misinterpret instructions, hallucinate data, select the wrong ticker, quantity, price, or order side, or execute trades that do not match your intent.
+
+**Prompt injection attacks.** Malicious content hidden in emails, documents, websites, files, or other data sources may hijack the AI into executing unauthorized trades or transferring assets without your knowledge.
+
+**Rogue or compromised Third-Party Terminal servers.** Third-Party Terminal servers may not be audited. A malicious or breached server may intercept credentials, manipulate market data, or trigger unauthorized actions.
+
+**Scope creep in multi‑step workflows.** Agentic AI may take broader actions than you intended when chaining tools, documents, or accounts.
+
+**Credential and session risks.** API keys, OAuth tokens, or session credentials used to authenticate the MCP connection may be leaked, reused, or abused.
+
+**Market risk amplified by automation.** Even technically correct orders may incur losses due to slippage, volatility, or timing, and errors may be executed faster than you can intervene.
+
+**Limited audit trail.** AI agent actions may not be fully captured by your broker's or employer's standard monitoring systems, making detection and recovery of unauthorized trades difficult.
+
+**Legal and regulatory exposure.** Trades executed by an AI agent on your account are generally treated as *your* trades. You remain fully responsible for all resulting losses, taxes, margin calls, and regulatory consequences.
+
+**6. General Terms**
+
+This Authorisation is governed by, and construed in accordance with, the laws of Hong Kong. Any dispute arising out of or in connection with this Authorisation shall be subject to the exclusive jurisdiction of the Hong Kong courts.
+
+This Authorisation supplements, but does not replace, the terms and conditions of Longbridge Platform, service rules including the Privacy Policy and other relevant terms or agreements. Please read carefully and thoroughly understand the foregoing documents and the contents of this Authorisation so as to make an informed authorization.
+
+Longbridge reserves the right to amend this Authorisation form from time to time. Material changes will be notified to you in advance and, where required by applicable law, will require your re-confirmation.
+
+If any provision of this Authorisation is found to be invalid or unenforceable, the remaining provisions shall continue in full force and effect.

--- a/docs/en/docs/legal/user-data-authorization-hk.md
+++ b/docs/en/docs/legal/user-data-authorization-hk.md
@@ -22,21 +22,21 @@ This Authorisation governs: (a) the sharing of your selected account data among 
 
 The categories of data covered by this Authorisation are displayed below and/or under "Quotes Permission" section on the OAuth authorisation page, and are subject to your selection. Unless otherwise specified, data related to securities trading will generally be shared by Long Bridge HK Limited ("**Longbridge Securities**"), while other data will be shared by Longbridge Platform (as defined in the terms and conditions of Longbridge Platform). The data categories authorised by you will be shared by Longbridge with Third-Party AI Terminals solely for the purpose of enabling the function of the Longbridge Developers described herein.
 
-The data categories that may be available include the following, with access granted on a feature-by-feature basis depending on the functionality selected on the relevant page:
+The data categories that may be available are organized into the following capability groups, with access granted on a feature-by-feature basis depending on the functionality selected on the relevant page. The specific set of available tools and their read / create / update / delete permissions may be added, adjusted or retired from time to time as Longbridge Developers evolves; the latest inventory is as published at [https://open.longbridge.com/docs/mcp](https://open.longbridge.com/docs/mcp) and on the OAuth authorization page:
 
-1. Watchlist --- Manage user watchlists (list / create / update / delete) and retrieve the securities contained in a specific watchlist for display and maintenance.
+1. **Real-time Market Data** --- Real-time market quotes and order-book data across markets.
 
-2. Trade Execution --- Buy, sell or any other operations about trade execution.
+2. **Fundamentals & Research** --- Company fundamentals and research data.
 
-3. Trade Order Lookup --- Cover the post-order-placement order lifecycle and execution capabilities, including order details and same-day / historical order queries, as well as same-day / historical trade report queries, and provide an estimate of the maximum purchasable quantity before placing an order.
+3. **Derivatives** --- Data relating to options, warrants and other derivatives.
 
-4. News & Filings --- Get the stock news.
+4. **Account & Portfolio** --- Access to account, cash and position data, and the maintenance of portfolio constructs such as watchlists.
 
-5. Account & Positions --- Provides read access to account asset and cash information, including fund holdings, stock holdings, account cash balance, and cash flow history for portfolio overview, position display, and reconciliation analysis.
+5. **Trading** --- Securities trade execution and the management of the order lifecycle.
 
-6. Market Sentiment --- Query "Market Temperature" (a fear-gauge-like sentiment thermometer) across equity markets, including current and historical readings for sentiment measurement, trend visualization, and comparative analysis.
+6. **Automation** --- Management of automated tasks triggered by conditions you have pre-set.
 
-Any other data categories that may be made available from time to time.
+The specific functionality, coverage and read / write permissions within the categories above may be adjusted or expanded from time to time. Any newly added data capability category will be presented as a separately selectable item on the OAuth authorization page before being shared with any Third-Party AI Terminal, and the corresponding data will only be shared after you have actively selected it and completed the authorization.
 
 **2.2 Further Sharing with Third-Party AI Terminals**
 
@@ -80,7 +80,7 @@ Third-Party AI Terminal may make errors in understanding or transmitting instruc
 
 Third-Party AI Terminal, as the entities responsible for AI terminal services, are obligated to comply with the PDPO and all other applicable Hong Kong laws in connection with the collection and processing of your data. You acknowledge that Longbridge does not control Third-Party AI Terminal's data practices and that you should review the privacy policies of any third-party AI terminal before use.
 
-**5. Risk Warning --- Connecting Your Securities Account**
+**5.** **Risk Warning --- Connecting Your Securities Account**
 
 Linking your brokerage or securities account to Third-Party Terminal grants the AI the ability to access account data and, depending on permissions, to place, modify, or cancel orders on your behalf. **This may result in partial or total loss of your assets.** By enabling this connection, you acknowledge and accept the following risks:
 

--- a/docs/en/docs/legal/user-data-authorization-sg.md
+++ b/docs/en/docs/legal/user-data-authorization-sg.md
@@ -22,21 +22,21 @@ This Authorisation governs: (a) the sharing of your selected account data among 
 
 The categories of data covered by this Authorisation are displayed below and/or under "Quotes Permission" section on the OAuth authorisation page, and are subject to your selection. Unless otherwise specified, data related to securities trading will generally be shared by Long Bridge Securities Pte. Ltd. ("**Longbridge Securities**"), while other data will be shared by Longbridge Platform (as defined in the Longbridge Platform Terms and Conditions), to Longbridge.
 
-The data categories that may be available include the following, with access granted on a feature-by-feature basis depending on the functionality selected on the relevant page:
+The data categories that may be available are organized into the following capability groups, with access granted on a feature-by-feature basis depending on the functionality selected on the relevant page. The specific set of available tools and their read / create / update / delete permissions may be added, adjusted or retired from time to time as Longbridge Developers evolves; the latest inventory is as published at [https://open.longbridge.com/docs/mcp](https://open.longbridge.com/docs/mcp) and on the OAuth authorization page:
 
-Watchlist --- Manage user watchlists (list / create / update / delete) and retrieve the securities contained in a specific watchlist for display and maintenance.
+1. **Real-time Market Data** --- Real-time market quotes and order-book data across markets.
 
-Trade Execution --- Buy, sell or any other operations about trade execution.
+2. **Fundamentals & Research** --- Company fundamentals and research data.
 
-Trade Order Lookup --- Cover the post-order-placement order lifecycle and execution capabilities, including order details and same-day / historical order queries, as well as same-day / historical trade report queries, and provide an estimate of the maximum purchasable quantity before placing an order.
+3. **Derivatives** --- Data relating to options, warrants and other derivatives.
 
-News & Filings --- Get the stock news.
+4. **Account & Portfolio** --- Access to account, cash and position data, and the maintenance of portfolio constructs such as watchlists.
 
-Account & Positions --- Provides read access to account asset and cash information, including fund holdings, stock holdings, account cash balance, and cash flow history for portfolio overview, position display, and reconciliation analysis.
+5. **Trading** --- Securities trade execution and the management of the order lifecycle.
 
-Market Sentiment --- Query "Market Temperature" (a fear-gauge-like sentiment thermometer) across equity markets, including current and historical readings for sentiment measurement, trend visualization, and comparative analysis.
+6. **Automation** --- Management of automated tasks triggered by conditions you have pre-set.
 
-Any other data categories that may be made available from time to time.
+The specific functionality, coverage and read / write permissions within the categories above may be adjusted or expanded from time to time. Any newly added data capability category will be presented as a separately selectable item on the OAuth authorization page before being shared with any Third-Party AI Terminal, and the corresponding data will only be shared after you have actively selected it and completed the authorization.
 
 **2.2 Further Sharing with Third-Party AI Terminals**
 

--- a/docs/en/docs/legal/user-data-authorization-sg.md
+++ b/docs/en/docs/legal/user-data-authorization-sg.md
@@ -1,0 +1,93 @@
+---
+title: 'User Data Authorisation and Acknowledgement — SG'
+sidebar_label: 'Data Authorisation (SG)'
+id: legal_user-data-authorization-sg
+slug: '/legal/user-data-authorization-sg'
+sidebar_position: 2
+---
+
+Please read this Authorisation carefully before proceeding. **By completing and submitting this Authorisation, you acknowledge and confirm that you have read, understood, and agree to be bound by all terms set out below in connection with the Longbridge Developers.**
+
+**1. Background**
+
+Longbridge AI Technology Pte. Ltd. and its affiliates (collectively, "**Longbridge**") provide programmatic interfaces through which market data, account functionalities, and related services are encapsulated and made available to users in the form of Command-Line Interface tools, Model Context Protocol integrations, and other developer tools and services (collectively, "**Longbridge Developers**").
+
+You may access and invoke the relevant interfaces based on your own needs and integrate them with third-party AI terminals or applications you select (including, without limitation, OpenClaw, Claude Code, Cursor, and similar tools) ("**Third-Party AI Terminals**"). Upon installation and successful connection, users may interact with the Longbridge Platform and/or their platform or securities accounts (where applicable) through such third-party terminals or applications.
+
+This Authorisation governs: (a) the sharing of your selected account data among the relevant Longbridge group entities and with relevant Third-Party AI Terminals ; and (b) the terms on which instructions you issue through Third-Party AI Terminals are treated as your own instructions for the purpose of executing securities transactions.
+
+**2. Data Sharing Authorisation and Purpose of Sharing**
+
+**2.1 Authorised Data Scope**
+
+The categories of data covered by this Authorisation are displayed below and/or under "Quotes Permission" section on the OAuth authorisation page, and are subject to your selection. Unless otherwise specified, data related to securities trading will generally be shared by Long Bridge Securities Pte. Ltd. ("**Longbridge Securities**"), while other data will be shared by Longbridge Platform (as defined in the Longbridge Platform Terms and Conditions), to Longbridge.
+
+The data categories that may be available include the following, with access granted on a feature-by-feature basis depending on the functionality selected on the relevant page:
+
+Watchlist --- Manage user watchlists (list / create / update / delete) and retrieve the securities contained in a specific watchlist for display and maintenance.
+
+Trade Execution --- Buy, sell or any other operations about trade execution.
+
+Trade Order Lookup --- Cover the post-order-placement order lifecycle and execution capabilities, including order details and same-day / historical order queries, as well as same-day / historical trade report queries, and provide an estimate of the maximum purchasable quantity before placing an order.
+
+News & Filings --- Get the stock news.
+
+Account & Positions --- Provides read access to account asset and cash information, including fund holdings, stock holdings, account cash balance, and cash flow history for portfolio overview, position display, and reconciliation analysis.
+
+Market Sentiment --- Query "Market Temperature" (a fear-gauge-like sentiment thermometer) across equity markets, including current and historical readings for sentiment measurement, trend visualization, and comparative analysis.
+
+Any other data categories that may be made available from time to time.
+
+**2.2 Further Sharing with Third-Party AI Terminals**
+
+By granting authorisation hereunder, you acknowledge and agree that the authorisation you hereby grant to Longbridge may, to the extent necessary to fulfil the purposes of Longbridge Developers and strictly in accordance with the PDPA, be further shared with Third-Party AI Terminals that you deploy. Each such Third-Party AI Terminals shall be responsible for the AI services they provide to you, and shall be independently responsible for their compliance with applicable laws and regulations, including the PDPA.
+
+You acknowledge that Longbridge does not control Third-Party AI Terminals' data practices and that you should review the privacy policies of any Third-Party AI Terminals before use.
+
+**2.3 Purpose of Sharing**
+
+The data shared pursuant to your selections above will be used exclusively to enable the functionality of the Longbridge Developer. No data will be shared for any other purpose without your separate consent.
+
+**2.4 Data Protection, Access Control and Compliance**
+
+All data collection, storage, and processing activities are conducted in accordance with the Personal Data Protection Act 2012 of Singapore ("**PDPA**") and other applicable data protection regulations. Longbridge will only retain your data for as long as is necessary to fulfil the purposes set out in this Authorisation, or as required by applicable laws. You have the right to withdraw your consent, access your data, and request correction of inaccurate data, in each case in accordance with the PDPA. You may withdraw this Authorisation at any time by updating your settings within the Longbridge platform. Withdrawal will take effect prospectively and will not affect instructions already submitted or executed prior to the effective date of withdrawal. You may revoke or disconnect Third-Party AI Terminal access at any time through the platform settings or other designated methods made available by Longbridge. Certain access or functionality may be suspended, restricted, or terminated where reasonably necessary for security, system protection, operational, compliance, or risk management purposes.
+
+**3. Nature and Effect of Instructions via Third-Party AI Terminals(when applicable)**
+
+You acknowledge and agree that when you issue instructions through Third-Party AI Terminals, which instructions shall be transmitted to and executed by Longbridge Securities:
+
+Longbridge acts solely as the developer of the Longbridge Developers. Longbridge does not control, review, endorse, or assume any responsibility or liability for the content, instructions, recommendations, or outputs generated by any Third-Party AI Terminal, including any trading decisions or outcomes arising therefrom. The Third-Party AI Terminal you selectis the responsible party for the AI services provided to you and you remain solely responsible for independently evaluating and verifying any information or recommendations provided by Third-Party AI Terminal before taking any action.
+
+The Third-Party AI Terminal transmits instructions on your behalf to Longbridge Securities for execution, but does not itself initiate, modify, interpret, or exercise any discretion over any instruction. Each instruction transmitted via Third-Party AI Terminal must be initiated by you through an explicit and deliberate user action. No instruction will be automatically generated, triggered, or executed without your input and confirmation.
+
+No Third-Party AI Terminal has constituted/ currently constitutes /will constitute an agent, representative, investment adviser, or decision-making entity of any Longbridge group entity or of you personally.
+
+Securities services and brokerage functions referred to in this Authorisation are provided by Longbridge Securities, a capital markets services licence holder regulated by the Monetary Authority of Singapore.
+
+Longbridge Securities executes instructions strictly in accordance with your authorisation, on an execution-only basis, without providing investment advice or exercising discretion.
+
+**By granting this Authorisation, you expressly permit the Third-Party AI Terminal you select to submit trading instructions to Longbridge Securities on your behalf. Such instructions, once confirmed and transmitted, shall be treated as your own instructions to Longbridge Securities and shall be binding upon execution. Each instruction originates from, and is solely attributable to, you as the account holder. You agree that Longbridge Securities is entitled to act on such instructions without further verification of your identity beyond the authentication carried out at login.**
+
+**4. Risk Acknowledgement**
+
+You acknowledge and accept the following risks:
+
+The value of investments may rise or fall and past performance is not indicative of future results.
+
+Instructions transmitted via Third-Party AI Terminal on behalf of you to Longbridge are binding upon execution. Longbridge shall not be liable for any losses arising from instructions that you authorise, including instructions transmitted through any Third-Party AI Terminal.
+
+You are solely responsible for reviewing and verifying the accuracy of all instructions before they are submitted, regardless of the interface used.
+
+Third-Party AI Terminal may make errors in understanding or transmitting instructions. You should always confirm the details of any instruction before authorising it.
+
+Third-Party Terminals, as the entities responsible for AI terminal services, are obligated to comply with the PDPA and all other applicable Singapore laws in connection with the collection and processing of your data. You acknowledge that Longbridge does not control Third-Party Terminals' data practices and that you should review the privacy policies of any third-party AI terminal before use.
+
+**5. General Terms**
+
+This Authorisation is governed by, and construed in accordance with, the laws of Singapore. Any dispute arising out of or in connection with this Authorisation shall be subject to the exclusive jurisdiction of the Singapore courts.
+
+This Authorisation supplements, but does not replace, the [Longbridge Platform Terms and Conditions](https://support.longbridge.sg/topics/us-trade/user-agreement?locale=en) , the [Privacy Policy](https://support.longbridge.sg/topics/Other/privacy-policy?locale=en) and other relevant terms or agreements. Please read carefully and understand thoroughly the foregoing documents and the contents of this Statement so as to make an informed authorization.
+
+Longbridge reserves the right to amend this Authorisation form from time to time. Material changes will be notified to you in advance and, where required by applicable law, will require your re-confirmation.
+
+If any provision of this Authorisation is found to be invalid or unenforceable, the remaining provisions shall continue in full force and effect.

--- a/docs/en/docs/market/_category_.json
+++ b/docs/en/docs/market/_category_.json
@@ -1,7 +1,7 @@
 {
   "label": "Market",
   "collapsible": true,
-  "collapsed": true,
+  "collapsed": false,
   "link": null,
   "position": 3.7
 }

--- a/docs/zh-CN/docs/legal/_category_.json
+++ b/docs/zh-CN/docs/legal/_category_.json
@@ -1,0 +1,8 @@
+{
+  "position": 8,
+  "label": "法律文件",
+  "collapsible": true,
+  "collapsed": true,
+  "link": null,
+  "icon": "book"
+}

--- a/docs/zh-CN/docs/legal/user-data-authorization-hk.md
+++ b/docs/zh-CN/docs/legal/user-data-authorization-hk.md
@@ -22,21 +22,21 @@ Longbridge AI Technologies Limited 及其相关关联公司（统称"**Longbridg
 
 本授权书所涵盖的数据类别如下文及/或 OAuth 授权页面 "Quotes Permission" 部分所示，以您的选择为准。除非另有说明，与证券交易相关的数据一般由 Long Bridge HK Limited（"**Longbridge Securities**"）共享，其他数据则由 Longbridge Platform（定义见 Longbridge Platform 的条款与条件）共享。您所授权的数据类别将由 Longbridge 仅出于实现本授权书所述 Longbridge Developers 功能之目的与 Third-Party AI Terminals 共享。
 
-可能可用的数据类别包括以下各项，访问权限按功能逐项授予，取决于您在相关页面所选功能：
+可能可用的数据类别按以下能力分组对外提供，访问权限按功能逐项授予，取决于您在相关页面所选功能。具体可用的工具集及其读取 / 创建 / 更新 / 删除权限随 Longbridge Developers 产品迭代不时新增、调整或下线，最新清单以 [https://open.longbridge.com/docs/mcp](https://open.longbridge.com/docs/mcp) 及 OAuth 授权页面所示为准：
 
-1. Watchlist —— 管理用户自选股清单（列表 / 创建 / 更新 / 删除），以及检索特定自选股清单中所包含的证券，用于展示和维护。
+1. **Real-time Market Data（实时行情数据）** —— 跨市场的实时行情与盘面数据。
 
-2. Trade Execution —— 买入、卖出或任何其他与交易执行相关的操作。
+2. **Fundamentals & Research（基本面与研究）** —— 公司基本面与研究类数据。
 
-3. Trade Order Lookup —— 涵盖下单后的订单生命周期与执行能力，包括订单详情、当日 / 历史订单查询、当日 / 历史成交记录查询，并在下单前提供最大可购买数量的估算。
+3. **Derivatives（衍生品）** —— 期权、权证等衍生品相关数据。
 
-4. News & Filings —— 获取股票新闻。
+4. **Account & Portfolio（账户与投资组合）** —— 账户、资金、持仓等组合数据的访问，以及自选股等组合配置的维护。
 
-5. Account & Positions —— 提供账户资产与现金信息的只读访问，包括基金持仓、股票持仓、账户现金余额以及现金流历史，用于投资组合概览、持仓展示与对账分析。
+5. **Trading（交易）** —— 证券交易执行及订单生命周期管理。
 
-6. Market Sentiment —— 查询跨股票市场的 "Market Temperature"（类似恐惧指数的情绪温度计），包括当前及历史读数，用于情绪测量、趋势可视化和对比分析。
+6. **Automation（自动化）** —— 基于您预设条件触发的自动化任务的管理。
 
-不时可能提供的任何其他数据类别。
+上述类别下的具体功能、覆盖范围及读 / 写权限可能不时调整或扩展。任何新增的数据能力类别在向 Third-Party AI Terminals 共享前，将在 OAuth 授权页面以单独的可勾选项呈现，您仅在主动勾选并完成授权后，相应数据方会被共享。
 
 **2.2 与 Third-Party AI Terminals 的进一步共享**
 
@@ -80,7 +80,7 @@ Third-Party AI Terminal 在理解或传输指令时可能出错。您应在授�
 
 Third-Party AI Terminal 作为提供 AI 终端服务的实体，在收集和处理您的数据方面有义务遵守 PDPO 及所有其他适用的香港法律。您确认 Longbridge 不控制 Third-Party AI Terminal 的数据实践，您应在使用前查阅任何第三方 AI 终端的隐私政策。
 
-**5. 风险提示 —— 连接您的证券账户**
+**5.** **风险提示 —— 连接您的证券账户**
 
 将您的经纪或证券账户连接至 Third-Party Terminal 会授予 AI 访问账户数据的能力，并视权限设置可代表您进行下单、修改或撤销订单。**这可能导致您的资产部分或全部损失。** 通过启用此连接，您确认并接受以下风险：
 

--- a/docs/zh-CN/docs/legal/user-data-authorization-hk.md
+++ b/docs/zh-CN/docs/legal/user-data-authorization-hk.md
@@ -1,0 +1,111 @@
+---
+title: '用户数据授权与确认 — 香港'
+sidebar_label: '数据授权确认（香港）'
+id: legal_user-data-authorization-hk
+slug: '/legal/user-data-authorization-hk'
+sidebar_position: 1
+---
+
+请在继续之前仔细阅读本授权书。**通过完成并提交本授权书，您即确认您已阅读、理解并同意受以下与 Longbridge Developers 相关的全部条款约束。**
+
+**1. 背景**
+
+Longbridge AI Technologies Limited 及其相关关联公司（统称"**Longbridge**"）通过封装行情数据、账户功能及相关服务，并以 CLI 工具、MCP 集成以及其他开发者工具和服务的形式提供给用户（统称"**Longbridge Developers**"）。
+
+用户可根据自身需要访问和调用相关接口，并将其与所选第三方 AI 终端或应用程序（包括但不限于 OpenClaw、Claude Code、Cursor 及类似工具）集成。安装并成功连接后，用户可通过此类第三方终端或应用程序与 Longbridge Platform 和/或其平台账户或证券账户（如适用）进行交互。
+
+本授权书规范：（a）您所选择的账户数据在相关 Longbridge 集团实体之间，以及与您所选择的相关第三方 AI 终端运营方（"**Third-Party AI Terminals**"）之间的共享；以及（b）您通过 Third-Party AI Terminals 发出的指令被视为您本人指令、用于执行证券交易的条款。
+
+**2. 数据共享授权及共享目的**
+
+**2.1 已授权数据范围**
+
+本授权书所涵盖的数据类别如下文及/或 OAuth 授权页面 "Quotes Permission" 部分所示，以您的选择为准。除非另有说明，与证券交易相关的数据一般由 Long Bridge HK Limited（"**Longbridge Securities**"）共享，其他数据则由 Longbridge Platform（定义见 Longbridge Platform 的条款与条件）共享。您所授权的数据类别将由 Longbridge 仅出于实现本授权书所述 Longbridge Developers 功能之目的与 Third-Party AI Terminals 共享。
+
+可能可用的数据类别包括以下各项，访问权限按功能逐项授予，取决于您在相关页面所选功能：
+
+1. Watchlist —— 管理用户自选股清单（列表 / 创建 / 更新 / 删除），以及检索特定自选股清单中所包含的证券，用于展示和维护。
+
+2. Trade Execution —— 买入、卖出或任何其他与交易执行相关的操作。
+
+3. Trade Order Lookup —— 涵盖下单后的订单生命周期与执行能力，包括订单详情、当日 / 历史订单查询、当日 / 历史成交记录查询，并在下单前提供最大可购买数量的估算。
+
+4. News & Filings —— 获取股票新闻。
+
+5. Account & Positions —— 提供账户资产与现金信息的只读访问，包括基金持仓、股票持仓、账户现金余额以及现金流历史，用于投资组合概览、持仓展示与对账分析。
+
+6. Market Sentiment —— 查询跨股票市场的 "Market Temperature"（类似恐惧指数的情绪温度计），包括当前及历史读数，用于情绪测量、趋势可视化和对比分析。
+
+不时可能提供的任何其他数据类别。
+
+**2.2 与 Third-Party AI Terminals 的进一步共享**
+
+通过授予本授权，您确认并同意您在此向 Longbridge 授予的授权可在实现 Longbridge Developers 目的所必需的范围内进一步与 Third-Party AI Terminals 共享。
+
+**2.3 共享目的**
+
+根据您上述选择共享的数据将专门用于实现 Longbridge Developers 的功能。未经您另行同意，不会出于任何其他目的共享任何数据。
+
+**2.4 数据保护与合规**
+
+所有数据收集、存储和处理活动均依据《个人资料（私隐）条例》（"**PDPO**"）以及其他适用的数据保护法规进行。Longbridge 仅在为实现本授权书所述目的所需期间，或在适用法律要求的期间内保留您的数据。您有权撤回同意、访问您的数据以及请求更正不准确的数据，在各种情形下均依据 PDPO 进行。您可随时通过在 Longbridge 平台内更新设置撤回本授权书。撤回自将来生效，不会影响在撤回生效日期之前已提交或已执行的指令。
+
+**3. 通过 Third-Party AI Terminals 传输的指令**
+
+**3.1 通过 Third-Party AI Terminals 发出指令的性质与效力（适用时）**
+
+您确认并同意，当您通过 Third-Party AI Terminals 发出指令，且该等指令应被传输至 Longbridge Securities 并由其执行时：
+
+Longbridge 仅作为 Longbridge Developers 的开发者。Longbridge 及 Longbridge Securities 不控制、不审查、不背书，亦不就任何 Third-Party AI Terminal 所生成的内容、指令、建议或输出承担任何责任，包括因此产生的任何交易决策或结果。与您互动的 Third-Party AI Terminal 是向您提供 AI 服务的责任方，您仍须在采取任何行动之前独立评估并验证 Third-Party AI Terminal 所提供的任何信息或建议。
+
+Third-Party AI Terminal 代表您将指令传输至 Longbridge Securities 以供执行，但其自身不会就任何指令进行发起、修改、解读或行使任何自由裁量权。每条通过 Third-Party AI Terminal 传输的指令必须由您通过明确且有意识的用户操作发起。未经您输入和确认，不会自动生成、触发或执行任何指令。
+
+任何 Third-Party AI Terminal 未曾、目前不构成、且不会构成任何 Longbridge 集团实体或您个人的代理人、代表、投资顾问或决策实体。
+
+Longbridge Securities 严格按照您的授权执行指令，仅以执行为基础，不提供投资建议，亦不行使自由裁量权。
+
+**通过授予本授权书，您明确允许您部署的 Third-Party AI Terminal 代表您向 Longbridge Securities 提交订单指令。该等指令一经确认和传输，应被视为您本人向 Longbridge Securities 发出的指令，并在执行后对您具有约束力。每条指令均源自您本人，且仅可归因于您作为账户持有人。您同意，Longbridge Securities 有权根据该等指令采取行动，除登录时已进行的身份验证之外，无需进一步验证您的身份。**
+
+**4. 风险确认**
+
+您确认并接受以下风险：
+
+投资价值可能涨跌，过往表现不代表未来结果。
+
+通过 Third-Party AI Terminal 代表您向 Longbridge 传输的指令在执行后对您具有约束力。Longbridge 对因您所授权的指令（包括通过任何 Third-Party AI Terminal 传输的指令）所产生的任何损失不承担责任。
+
+无论使用何种界面，您均须独自负责在提交所有指令之前对其准确性进行审查和验证。
+
+Third-Party AI Terminal 在理解或传输指令时可能出错。您应在授权任何指令之前始终确认其细节。
+
+Third-Party AI Terminal 作为提供 AI 终端服务的实体，在收集和处理您的数据方面有义务遵守 PDPO 及所有其他适用的香港法律。您确认 Longbridge 不控制 Third-Party AI Terminal 的数据实践，您应在使用前查阅任何第三方 AI 终端的隐私政策。
+
+**5. 风险提示 —— 连接您的证券账户**
+
+将您的经纪或证券账户连接至 Third-Party Terminal 会授予 AI 访问账户数据的能力，并视权限设置可代表您进行下单、修改或撤销订单。**这可能导致您的资产部分或全部损失。** 通过启用此连接，您确认并接受以下风险：
+
+**AI 错误。** Third-Party Terminal 可能误解指令、产生数据幻觉、选错股票代码、数量、价格或订单方向，或执行不符合您意图的交易。
+
+**Prompt 注入攻击。** 隐藏在电子邮件、文档、网站、文件或其他数据源中的恶意内容可能劫持 AI，使其在您不知情的情况下执行未经授权的交易或转移资产。
+
+**恶意或受损的 Third-Party Terminal 服务器。** Third-Party Terminal 服务器可能未经审核。恶意或被入侵的服务器可能拦截凭证、操纵市场数据，或触发未经授权的操作。
+
+**多步骤工作流中的范围蔓延。** Agentic AI 在串联工具、文档或账户时可能采取超出您意图的更广泛行动。
+
+**凭证与会话风险。** 用于认证 MCP 连接的 API Keys、OAuth tokens 或会话凭证可能被泄露、复用或滥用。
+
+**自动化放大的市场风险。** 即使技术上正确的订单也可能因滑点、波动或时机而招致损失，且错误的执行速度可能快于您介入的速度。
+
+**审计追踪有限。** AI Agent 的操作可能未被您的经纪商或雇主的标准监控系统完全捕获，难以检测和恢复未经授权的交易。
+
+**法律与监管风险。** AI Agent 在您账户上执行的交易通常被视为*您本人的*交易。您对所有由此产生的损失、税务、追加保证金通知和监管后果承担全部责任。
+
+**6. 一般条款**
+
+本授权书受香港法律管辖并据其解释。任何由本授权书产生或与本授权书相关的争议均应受香港法院专属管辖。
+
+本授权书补充但不替代 Longbridge Platform 的条款与条件、包括《隐私政策》在内的服务规则及其他相关条款或协议。请仔细阅读并彻底理解上述文件及本授权书的内容，以做出知情的授权。
+
+Longbridge 保留不时修订本授权书的权利。重大变更将提前通知您，并在适用法律要求时需要您重新确认。
+
+如本授权书的任何条款被认定为无效或不可执行，其余条款应继续完全有效。

--- a/docs/zh-CN/docs/legal/user-data-authorization-sg.md
+++ b/docs/zh-CN/docs/legal/user-data-authorization-sg.md
@@ -1,0 +1,93 @@
+---
+title: '用户数据授权与确认 — 新加坡'
+sidebar_label: '数据授权确认（新加坡）'
+id: legal_user-data-authorization-sg
+slug: '/legal/user-data-authorization-sg'
+sidebar_position: 2
+---
+
+请在继续之前仔细阅读本授权书。**通过完成并提交本授权书，您即确认您已阅读、理解并同意受以下与 Longbridge Developers 相关的全部条款约束。**
+
+**1. 背景**
+
+Longbridge AI Technology Pte. Ltd. 及其关联公司（统称"**Longbridge**"）通过封装行情数据、账户功能及相关服务，并以 CLI 工具、MCP 集成以及其他开发者工具和服务的形式提供给用户（统称"**Longbridge Developers**"）。
+
+您可根据自身需要访问和调用相关接口，并将其与所选第三方 AI 终端或应用程序（包括但不限于 OpenClaw、Claude Code、Cursor 及类似工具）集成（"**Third-Party AI Terminals**"）。安装并成功连接后，用户可通过此类第三方终端或应用程序与 Longbridge Platform 和/或其平台账户或证券账户（如适用）进行交互。
+
+本授权书规范：（a）您所选择的账户数据在相关 Longbridge 集团实体之间，以及与相关 Third-Party AI Terminals 之间的共享；以及（b）您通过 Third-Party AI Terminals 发出的指令被视为您本人指令、用于执行证券交易的条款。
+
+**2. 数据共享授权及共享目的**
+
+**2.1 已授权数据范围**
+
+本授权书所涵盖的数据类别如下文及/或 OAuth 授权页面 "Quotes Permission" 部分所示，以您的选择为准。除非另有说明，与证券交易相关的数据一般由 Long Bridge Securities Pte. Ltd.（"**Longbridge Securities**"）共享给 Longbridge，其他数据则由 Longbridge Platform（定义见 Longbridge Platform 条款与条件）共享给 Longbridge。
+
+可能可用的数据类别包括以下各项，访问权限按功能逐项授予，取决于您在相关页面所选功能：
+
+1. Watchlist —— 管理用户自选股清单（列表 / 创建 / 更新 / 删除），以及检索特定自选股清单中所包含的证券，用于展示和维护。
+
+2. Trade Execution —— 买入、卖出或任何其他与交易执行相关的操作。
+
+3. Trade Order Lookup —— 涵盖下单后的订单生命周期与执行能力，包括订单详情、当日 / 历史订单查询、当日 / 历史成交记录查询，并在下单前提供最大可购买数量的估算。
+
+4. News & Filings —— 获取股票新闻。
+
+5. Account & Positions —— 提供账户资产与现金信息的只读访问，包括基金持仓、股票持仓、账户现金余额以及现金流历史，用于投资组合概览、持仓展示与对账分析。
+
+6. Market Sentiment —— 查询跨股票市场的 "Market Temperature"（类似恐惧指数的情绪温度计），包括当前及历史读数，用于情绪测量、趋势可视化和对比分析。
+
+不时可能提供的任何其他数据类别。
+
+**2.2 与 Third-Party AI Terminals 的进一步共享**
+
+通过授予本授权，您确认并同意您在此向 Longbridge 授予的授权可在实现 Longbridge Developers 目的所必需的范围内，并严格依照 PDPA，进一步与您部署的 Third-Party AI Terminals 共享。每个此类 Third-Party AI Terminals 须就其向您提供的 AI 服务负责，并独立承担其遵守适用法律法规（包括 PDPA）的责任。
+
+您确认 Longbridge 不控制 Third-Party AI Terminals 的数据实践，您应在使用前查阅任何 Third-Party AI Terminals 的隐私政策。
+
+**2.3 共享目的**
+
+根据您上述选择共享的数据将专门用于实现 Longbridge Developer 的功能。未经您另行同意，不会出于任何其他目的共享任何数据。
+
+**2.4 数据保护、访问控制与合规**
+
+所有数据收集、存储和处理活动均依据《新加坡 2012 年个人数据保护法令》（"**PDPA**"）以及其他适用的数据保护法规进行。Longbridge 仅在为实现本授权书所述目的所需期间，或在适用法律要求的期间内保留您的数据。您有权撤回同意、访问您的数据以及请求更正不准确的数据，在各种情形下均依据 PDPA 进行。您可随时通过在 Longbridge 平台内更新设置撤回本授权书。撤回自将来生效，不会影响在撤回生效日期之前已提交或已执行的指令。您可随时通过平台设置或 Longbridge 提供的其他指定方式撤销或断开 Third-Party AI Terminal 的访问。出于安全、系统保护、运营、合规或风险管理目的之合理必要情形下，某些访问或功能可能被暂停、限制或终止。
+
+**3. 通过 Third-Party AI Terminals 发出指令的性质与效力（适用时）**
+
+您确认并同意，当您通过 Third-Party AI Terminals 发出指令，且该等指令应被传输至 Longbridge Securities 并由其执行时：
+
+Longbridge 仅作为 Longbridge Developers 的开发者。Longbridge 不控制、不审查、不背书，亦不就任何 Third-Party AI Terminal 所生成的内容、指令、建议或输出承担任何责任，包括因此产生的任何交易决策或结果。您所选择的 Third-Party AI Terminal 是向您提供 AI 服务的责任方，您仍须在采取任何行动之前独立评估并验证 Third-Party AI Terminal 所提供的任何信息或建议。
+
+Third-Party AI Terminal 代表您将指令传输至 Longbridge Securities 以供执行，但其自身不会就任何指令进行发起、修改、解读或行使任何自由裁量权。每条通过 Third-Party AI Terminal 传输的指令必须由您通过明确且有意识的用户操作发起。未经您输入和确认，不会自动生成、触发或执行任何指令。
+
+任何 Third-Party AI Terminal 未曾、目前不构成、且不会构成任何 Longbridge 集团实体或您个人的代理人、代表、投资顾问或决策实体。
+
+本授权书所述的证券服务及经纪职能由 Longbridge Securities 提供，该公司为受 Monetary Authority of Singapore 监管的资本市场服务牌照持有人。
+
+Longbridge Securities 严格按照您的授权执行指令，仅以执行为基础，不提供投资建议，亦不行使自由裁量权。
+
+**通过授予本授权书，您明确允许您所选择的 Third-Party AI Terminal 代表您向 Longbridge Securities 提交交易指令。该等指令一经确认和传输，应被视为您本人向 Longbridge Securities 发出的指令，并在执行后对您具有约束力。每条指令均源自您本人，且仅可归因于您作为账户持有人。您同意，Longbridge Securities 有权根据该等指令采取行动，除登录时已进行的身份验证之外，无需进一步验证您的身份。**
+
+**4. 风险确认**
+
+您确认并接受以下风险：
+
+投资价值可能涨跌，过往表现不代表未来结果。
+
+通过 Third-Party AI Terminal 代表您向 Longbridge 传输的指令在执行后对您具有约束力。Longbridge 对因您所授权的指令（包括通过任何 Third-Party AI Terminal 传输的指令）所产生的任何损失不承担责任。
+
+无论使用何种界面，您均须独自负责在提交所有指令之前对其准确性进行审查和验证。
+
+Third-Party AI Terminal 在理解或传输指令时可能出错。您应在授权任何指令之前始终确认其细节。
+
+Third-Party Terminals 作为提供 AI 终端服务的实体，在收集和处理您的数据方面有义务遵守 PDPA 及所有其他适用的新加坡法律。您确认 Longbridge 不控制 Third-Party Terminals 的数据实践，您应在使用前查阅任何第三方 AI 终端的隐私政策。
+
+**5. 一般条款**
+
+本授权书受新加坡法律管辖并据其解释。任何由本授权书产生或与本授权书相关的争议均应受新加坡法院专属管辖。
+
+本授权书补充但不替代 [Longbridge Platform Terms and Conditions](https://support.longbridge.sg/topics/us-trade/user-agreement?locale=en)、[Privacy Policy](https://support.longbridge.sg/topics/Other/privacy-policy?locale=en) 以及其他相关条款或协议。请仔细阅读并彻底理解上述文件及本声明的内容，以做出知情的授权。
+
+Longbridge 保留不时修订本授权书的权利。重大变更将提前通知您，并在适用法律要求时需要您重新确认。
+
+如本授权书的任何条款被认定为无效或不可执行，其余条款应继续完全有效。

--- a/docs/zh-CN/docs/legal/user-data-authorization-sg.md
+++ b/docs/zh-CN/docs/legal/user-data-authorization-sg.md
@@ -22,21 +22,21 @@ Longbridge AI Technology Pte. Ltd. 及其关联公司（统称"**Longbridge**"�
 
 本授权书所涵盖的数据类别如下文及/或 OAuth 授权页面 "Quotes Permission" 部分所示，以您的选择为准。除非另有说明，与证券交易相关的数据一般由 Long Bridge Securities Pte. Ltd.（"**Longbridge Securities**"）共享给 Longbridge，其他数据则由 Longbridge Platform（定义见 Longbridge Platform 条款与条件）共享给 Longbridge。
 
-可能可用的数据类别包括以下各项，访问权限按功能逐项授予，取决于您在相关页面所选功能：
+可能可用的数据类别按以下能力分组对外提供，访问权限按功能逐项授予，取决于您在相关页面所选功能。具体可用的工具集及其读取 / 创建 / 更新 / 删除权限随 Longbridge Developers 产品迭代不时新增、调整或下线，最新清单以 [https://open.longbridge.com/docs/mcp](https://open.longbridge.com/docs/mcp) 及 OAuth 授权页面所示为准：
 
-1. Watchlist —— 管理用户自选股清单（列表 / 创建 / 更新 / 删除），以及检索特定自选股清单中所包含的证券，用于展示和维护。
+1. **Real-time Market Data（实时行情数据）** —— 跨市场的实时行情与盘面数据。
 
-2. Trade Execution —— 买入、卖出或任何其他与交易执行相关的操作。
+2. **Fundamentals & Research（基本面与研究）** —— 公司基本面与研究类数据。
 
-3. Trade Order Lookup —— 涵盖下单后的订单生命周期与执行能力，包括订单详情、当日 / 历史订单查询、当日 / 历史成交记录查询，并在下单前提供最大可购买数量的估算。
+3. **Derivatives（衍生品）** —— 期权、权证等衍生品相关数据。
 
-4. News & Filings —— 获取股票新闻。
+4. **Account & Portfolio（账户与投资组合）** —— 账户、资金、持仓等组合数据的访问，以及自选股等组合配置的维护。
 
-5. Account & Positions —— 提供账户资产与现金信息的只读访问，包括基金持仓、股票持仓、账户现金余额以及现金流历史，用于投资组合概览、持仓展示与对账分析。
+5. **Trading（交易）** —— 证券交易执行及订单生命周期管理。
 
-6. Market Sentiment —— 查询跨股票市场的 "Market Temperature"（类似恐惧指数的情绪温度计），包括当前及历史读数，用于情绪测量、趋势可视化和对比分析。
+6. **Automation（自动化）** —— 基于您预设条件触发的自动化任务的管理。
 
-不时可能提供的任何其他数据类别。
+上述类别下的具体功能、覆盖范围及读 / 写权限可能不时调整或扩展。任何新增的数据能力类别在向 Third-Party AI Terminals 共享前，将在 OAuth 授权页面以单独的可勾选项呈现，您仅在主动勾选并完成授权后，相应数据方会被共享。
 
 **2.2 与 Third-Party AI Terminals 的进一步共享**
 

--- a/docs/zh-CN/docs/market/_category_.json
+++ b/docs/zh-CN/docs/market/_category_.json
@@ -1,7 +1,7 @@
 {
   "label": "市场",
   "collapsible": true,
-  "collapsed": true,
+  "collapsed": false,
   "link": null,
   "position": 3.7
 }

--- a/docs/zh-HK/docs/legal/_category_.json
+++ b/docs/zh-HK/docs/legal/_category_.json
@@ -1,0 +1,8 @@
+{
+  "position": 8,
+  "label": "法律文件",
+  "collapsible": true,
+  "collapsed": true,
+  "link": null,
+  "icon": "book"
+}

--- a/docs/zh-HK/docs/legal/user-data-authorization-hk.md
+++ b/docs/zh-HK/docs/legal/user-data-authorization-hk.md
@@ -22,21 +22,21 @@ Longbridge AI Technologies Limited 及其相關關聯公司（統稱"**Longbridg
 
 本授權書所涵蓋的數據類別如下文及/或 OAuth 授權頁面 "Quotes Permission" 部分所示，以您的選擇為準。除非另有説明，與證券交易相關的數據一般由 Long Bridge HK Limited（"**Longbridge Securities**"）共享，其他數據則由 Longbridge Platform（定義見 Longbridge Platform 的條款與條件）共享。您所授權的數據類別將由 Longbridge 僅出於實現本授權書所述 Longbridge Developers 功能之目的與 Third-Party AI Terminals 共享。
 
-可能可用的數據類別包括以下各項，訪問權限按功能逐項授予，取決於您在相關頁面所選功能：
+可能可用的數據類別按以下能力分組對外提供，訪問權限按功能逐項授予，取決於您在相關頁面所選功能。具體可用的工具集及其讀取 / 創建 / 更新 / 刪除權限隨 Longbridge Developers 產品迭代不時新增、調整或下線，最新清單以 [https://open.longbridge.com/docs/mcp](https://open.longbridge.com/docs/mcp) 及 OAuth 授權頁面所示為準：
 
-1. Watchlist —— 管理用户自選股清單（列表 / 創建 / 更新 / 刪除），以及檢索特定自選股清單中所包含的證券，用於展示和維護。
+1. **Real-time Market Data（實時行情數據）** —— 跨市場的實時行情與盤面數據。
 
-2. Trade Execution —— 買入、賣出或任何其他與交易執行相關的操作。
+2. **Fundamentals & Research（基本面與研究）** —— 公司基本面與研究類數據。
 
-3. Trade Order Lookup —— 涵蓋下單後的訂單生命週期與執行能力，包括訂單詳情、當日 / 歷史訂單查詢、當日 / 歷史成交記錄查詢，並在下單前提供最大可購買數量的估算。
+3. **Derivatives（衍生品）** —— 期權、權證等衍生品相關數據。
 
-4. News & Filings —— 獲取股票新聞。
+4. **Account & Portfolio（賬戶與投資組合）** —— 賬戶、資金、持倉等組合數據的訪問，以及自選股等組合配置的維護。
 
-5. Account & Positions —— 提供賬户資產與現金信息的只讀訪問，包括基金持倉、股票持倉、賬户現金餘額以及現金流歷史，用於投資組合概覽、持倉展示與對賬分析。
+5. **Trading（交易）** —— 證券交易執行及訂單生命週期管理。
 
-6. Market Sentiment —— 查詢跨股票市場的 "Market Temperature"（類似恐懼指數的情緒温度計），包括當前及歷史讀數，用於情緒測量、趨勢可視化和對比分析。
+6. **Automation（自動化）** —— 基於您預設條件觸發的自動化任務的管理。
 
-不時可能提供的任何其他數據類別。
+上述類別下的具體功能、覆蓋範圍及讀 / 寫權限可能不時調整或擴展。任何新增的數據能力類別在向 Third-Party AI Terminals 共享前，將在 OAuth 授權頁面以單獨的可勾選項呈現，您僅在主動勾選並完成授權後，相應數據方會被共享。
 
 **2.2 與 Third-Party AI Terminals 的進一步共享**
 
@@ -80,7 +80,7 @@ Third-Party AI Terminal 在理解或傳輸指令時可能出錯。您應在授�
 
 Third-Party AI Terminal 作為提供 AI 終端服務的實體，在收集和處理您的數據方面有義務遵守 PDPO 及所有其他適用的香港法律。您確認 Longbridge 不控制 Third-Party AI Terminal 的數據實踐，您應在使用前查閲任何第三方 AI 終端的隱私政策。
 
-**5. 風險提示 —— 連接您的證券賬户**
+**5.** **風險提示 —— 連接您的證券賬户**
 
 將您的經紀或證券賬户連接至 Third-Party Terminal 會授予 AI 訪問賬户數據的能力，並視權限設置可代表您進行下單、修改或撤銷訂單。**這可能導致您的資產部分或全部損失。** 通過啓用此連接，您確認並接受以下風險：
 

--- a/docs/zh-HK/docs/legal/user-data-authorization-hk.md
+++ b/docs/zh-HK/docs/legal/user-data-authorization-hk.md
@@ -1,0 +1,111 @@
+---
+title: '用户數據授權與確認 — 香港'
+sidebar_label: '數據授權確認（香港）'
+id: legal_user-data-authorization-hk
+slug: '/legal/user-data-authorization-hk'
+sidebar_position: 1
+---
+
+請在繼續之前仔細閲讀本授權書。**通過完成並提交本授權書，您即確認您已閲讀、理解並同意受以下與 Longbridge Developers 相關的全部條款約束。**
+
+**1. 背景**
+
+Longbridge AI Technologies Limited 及其相關關聯公司（統稱"**Longbridge**"）通過封裝行情數據、賬户功能及相關服務，並以 CLI 工具、MCP 集成以及其他開發者工具和服務的形式提供給用户（統稱"**Longbridge Developers**"）。
+
+用户可根據自身需要訪問和調用相關接口，並將其與所選第三方 AI 終端或應用程序（包括但不限於 OpenClaw、Claude Code、Cursor 及類似工具）集成。安裝併成功連接後，用户可通過此類第三方終端或應用程序與 Longbridge Platform 和/或其平台賬户或證券賬户（如適用）進行交互。
+
+本授權書規範：（a）您所選擇的賬户數據在相關 Longbridge 集團實體之間，以及與您所選擇的相關第三方 AI 終端運營方（"**Third-Party AI Terminals**"）之間的共享；以及（b）您通過 Third-Party AI Terminals 發出的指令被視為您本人指令、用於執行證券交易的條款。
+
+**2. 數據共享授權及共享目的**
+
+**2.1 已授權數據範圍**
+
+本授權書所涵蓋的數據類別如下文及/或 OAuth 授權頁面 "Quotes Permission" 部分所示，以您的選擇為準。除非另有説明，與證券交易相關的數據一般由 Long Bridge HK Limited（"**Longbridge Securities**"）共享，其他數據則由 Longbridge Platform（定義見 Longbridge Platform 的條款與條件）共享。您所授權的數據類別將由 Longbridge 僅出於實現本授權書所述 Longbridge Developers 功能之目的與 Third-Party AI Terminals 共享。
+
+可能可用的數據類別包括以下各項，訪問權限按功能逐項授予，取決於您在相關頁面所選功能：
+
+1. Watchlist —— 管理用户自選股清單（列表 / 創建 / 更新 / 刪除），以及檢索特定自選股清單中所包含的證券，用於展示和維護。
+
+2. Trade Execution —— 買入、賣出或任何其他與交易執行相關的操作。
+
+3. Trade Order Lookup —— 涵蓋下單後的訂單生命週期與執行能力，包括訂單詳情、當日 / 歷史訂單查詢、當日 / 歷史成交記錄查詢，並在下單前提供最大可購買數量的估算。
+
+4. News & Filings —— 獲取股票新聞。
+
+5. Account & Positions —— 提供賬户資產與現金信息的只讀訪問，包括基金持倉、股票持倉、賬户現金餘額以及現金流歷史，用於投資組合概覽、持倉展示與對賬分析。
+
+6. Market Sentiment —— 查詢跨股票市場的 "Market Temperature"（類似恐懼指數的情緒温度計），包括當前及歷史讀數，用於情緒測量、趨勢可視化和對比分析。
+
+不時可能提供的任何其他數據類別。
+
+**2.2 與 Third-Party AI Terminals 的進一步共享**
+
+通過授予本授權，您確認並同意您在此向 Longbridge 授予的授權可在實現 Longbridge Developers 目的所必需的範圍內進一步與 Third-Party AI Terminals 共享。
+
+**2.3 共享目的**
+
+根據您上述選擇共享的數據將專門用於實現 Longbridge Developers 的功能。未經您另行同意，不會出於任何其他目的共享任何數據。
+
+**2.4 數據保護與合規**
+
+所有數據收集、存儲和處理活動均依據《個人資料（私隱）條例》（"**PDPO**"）以及其他適用的數據保護法規進行。Longbridge 僅在為實現本授權書所述目的所需期間，或在適用法律要求的期間內保留您的數據。您有權撤回同意、訪問您的數據以及請求更正不準確的數據，在各種情形下均依據 PDPO 進行。您可隨時通過在 Longbridge 平台內更新設置撤回本授權書。撤回自將來生效，不會影響在撤回生效日期之前已提交或已執行的指令。
+
+**3. 通過 Third-Party AI Terminals 傳輸的指令**
+
+**3.1 通過 Third-Party AI Terminals 發出指令的性質與效力（適用時）**
+
+您確認並同意，當您通過 Third-Party AI Terminals 發出指令，且該等指令應被傳輸至 Longbridge Securities 並由其執行時：
+
+Longbridge 僅作為 Longbridge Developers 的開發者。Longbridge 及 Longbridge Securities 不控制、不審查、不背書，亦不就任何 Third-Party AI Terminal 所生成的內容、指令、建議或輸出承擔任何責任，包括因此產生的任何交易決策或結果。與您互動的 Third-Party AI Terminal 是向您提供 AI 服務的責任方，您仍須在採取任何行動之前獨立評估並驗證 Third-Party AI Terminal 所提供的任何信息或建議。
+
+Third-Party AI Terminal 代表您將指令傳輸至 Longbridge Securities 以供執行，但其自身不會就任何指令進行發起、修改、解讀或行使任何自由裁量權。每條通過 Third-Party AI Terminal 傳輸的指令必須由您通過明確且有意識的用户操作發起。未經您輸入和確認，不會自動生成、觸發或執行任何指令。
+
+任何 Third-Party AI Terminal 未曾、目前不構成、且不會構成任何 Longbridge 集團實體或您個人的代理人、代表、投資顧問或決策實體。
+
+Longbridge Securities 嚴格按照您的授權執行指令，僅以執行為基礎，不提供投資建議，亦不行使自由裁量權。
+
+**通過授予本授權書，您明確允許您部署的 Third-Party AI Terminal 代表您向 Longbridge Securities 提交訂單指令。該等指令一經確認和傳輸，應被視為您本人向 Longbridge Securities 發出的指令，並在執行後對您具有約束力。每條指令均源自您本人，且僅可歸因於您作為賬户持有人。您同意，Longbridge Securities 有權根據該等指令採取行動，除登錄時已進行的身份驗證之外，無需進一步驗證您的身份。**
+
+**4. 風險確認**
+
+您確認並接受以下風險：
+
+投資價值可能漲跌，過往表現不代表未來結果。
+
+通過 Third-Party AI Terminal 代表您向 Longbridge 傳輸的指令在執行後對您具有約束力。Longbridge 對因您所授權的指令（包括通過任何 Third-Party AI Terminal 傳輸的指令）所產生的任何損失不承擔責任。
+
+無論使用何種界面，您均須獨自負責在提交所有指令之前對其準確性進行審查和驗證。
+
+Third-Party AI Terminal 在理解或傳輸指令時可能出錯。您應在授權任何指令之前始終確認其細節。
+
+Third-Party AI Terminal 作為提供 AI 終端服務的實體，在收集和處理您的數據方面有義務遵守 PDPO 及所有其他適用的香港法律。您確認 Longbridge 不控制 Third-Party AI Terminal 的數據實踐，您應在使用前查閲任何第三方 AI 終端的隱私政策。
+
+**5. 風險提示 —— 連接您的證券賬户**
+
+將您的經紀或證券賬户連接至 Third-Party Terminal 會授予 AI 訪問賬户數據的能力，並視權限設置可代表您進行下單、修改或撤銷訂單。**這可能導致您的資產部分或全部損失。** 通過啓用此連接，您確認並接受以下風險：
+
+**AI 錯誤。** Third-Party Terminal 可能誤解指令、產生數據幻覺、選錯股票代碼、數量、價格或訂單方向，或執行不符合您意圖的交易。
+
+**Prompt 注入攻擊。** 隱藏在電子郵件、文檔、網站、文件或其他數據源中的惡意內容可能劫持 AI，使其在您不知情的情況下執行未經授權的交易或轉移資產。
+
+**惡意或受損的 Third-Party Terminal 服務器。** Third-Party Terminal 服務器可能未經審核。惡意或被入侵的服務器可能攔截憑證、操縱市場數據，或觸發未經授權的操作。
+
+**多步驟工作流中的範圍蔓延。** Agentic AI 在串聯工具、文檔或賬户時可能採取超出您意圖的更廣泛行動。
+
+**憑證與會話風險。** 用於認證 MCP 連接的 API Keys、OAuth tokens 或會話憑證可能被泄露、複用或濫用。
+
+**自動化放大的市場風險。** 即使技術上正確的訂單也可能因滑點、波動或時機而招致損失，且錯誤的執行速度可能快於您介入的速度。
+
+**審計追蹤有限。** AI Agent 的操作可能未被您的經紀商或僱主的標準監控系統完全捕獲，難以檢測和恢復未經授權的交易。
+
+**法律與監管風險。** AI Agent 在您賬户上執行的交易通常被視為*您本人的*交易。您對所有由此產生的損失、税務、追加保證金通知和監管後果承擔全部責任。
+
+**6. 一般條款**
+
+本授權書受香港法律管轄並據其解釋。任何由本授權書產生或與本授權書相關的爭議均應受香港法院專屬管轄。
+
+本授權書補充但不替代 Longbridge Platform 的條款與條件、包括《隱私政策》在內的服務規則及其他相關條款或協議。請仔細閲讀並徹底理解上述文件及本授權書的內容，以做出知情的授權。
+
+Longbridge 保留不時修訂本授權書的權利。重大變更將提前通知您，並在適用法律要求時需要您重新確認。
+
+如本授權書的任何條款被認定為無效或不可執行，其餘條款應繼續完全有效。

--- a/docs/zh-HK/docs/legal/user-data-authorization-sg.md
+++ b/docs/zh-HK/docs/legal/user-data-authorization-sg.md
@@ -22,21 +22,21 @@ Longbridge AI Technology Pte. Ltd. 及其關聯公司（統稱"**Longbridge**"�
 
 本授權書所涵蓋的數據類別如下文及/或 OAuth 授權頁面 "Quotes Permission" 部分所示，以您的選擇為準。除非另有説明，與證券交易相關的數據一般由 Long Bridge Securities Pte. Ltd.（"**Longbridge Securities**"）共享給 Longbridge，其他數據則由 Longbridge Platform（定義見 Longbridge Platform 條款與條件）共享給 Longbridge。
 
-可能可用的數據類別包括以下各項，訪問權限按功能逐項授予，取決於您在相關頁面所選功能：
+可能可用的數據類別按以下能力分組對外提供，訪問權限按功能逐項授予，取決於您在相關頁面所選功能。具體可用的工具集及其讀取 / 創建 / 更新 / 刪除權限隨 Longbridge Developers 產品迭代不時新增、調整或下線，最新清單以 [https://open.longbridge.com/docs/mcp](https://open.longbridge.com/docs/mcp) 及 OAuth 授權頁面所示為準：
 
-1. Watchlist —— 管理用户自選股清單（列表 / 創建 / 更新 / 刪除），以及檢索特定自選股清單中所包含的證券，用於展示和維護。
+1. **Real-time Market Data（實時行情數據）** —— 跨市場的實時行情與盤面數據。
 
-2. Trade Execution —— 買入、賣出或任何其他與交易執行相關的操作。
+2. **Fundamentals & Research（基本面與研究）** —— 公司基本面與研究類數據。
 
-3. Trade Order Lookup —— 涵蓋下單後的訂單生命週期與執行能力，包括訂單詳情、當日 / 歷史訂單查詢、當日 / 歷史成交記錄查詢，並在下單前提供最大可購買數量的估算。
+3. **Derivatives（衍生品）** —— 期權、權證等衍生品相關數據。
 
-4. News & Filings —— 獲取股票新聞。
+4. **Account & Portfolio（賬戶與投資組合）** —— 賬戶、資金、持倉等組合數據的訪問，以及自選股等組合配置的維護。
 
-5. Account & Positions —— 提供賬户資產與現金信息的只讀訪問，包括基金持倉、股票持倉、賬户現金餘額以及現金流歷史，用於投資組合概覽、持倉展示與對賬分析。
+5. **Trading（交易）** —— 證券交易執行及訂單生命週期管理。
 
-6. Market Sentiment —— 查詢跨股票市場的 "Market Temperature"（類似恐懼指數的情緒温度計），包括當前及歷史讀數，用於情緒測量、趨勢可視化和對比分析。
+6. **Automation（自動化）** —— 基於您預設條件觸發的自動化任務的管理。
 
-不時可能提供的任何其他數據類別。
+上述類別下的具體功能、覆蓋範圍及讀 / 寫權限可能不時調整或擴展。任何新增的數據能力類別在向 Third-Party AI Terminals 共享前，將在 OAuth 授權頁面以單獨的可勾選項呈現，您僅在主動勾選並完成授權後，相應數據方會被共享。
 
 **2.2 與 Third-Party AI Terminals 的進一步共享**
 

--- a/docs/zh-HK/docs/legal/user-data-authorization-sg.md
+++ b/docs/zh-HK/docs/legal/user-data-authorization-sg.md
@@ -1,0 +1,93 @@
+---
+title: '用户數據授權與確認 — 新加坡'
+sidebar_label: '數據授權確認（新加坡）'
+id: legal_user-data-authorization-sg
+slug: '/legal/user-data-authorization-sg'
+sidebar_position: 2
+---
+
+請在繼續之前仔細閲讀本授權書。**通過完成並提交本授權書，您即確認您已閲讀、理解並同意受以下與 Longbridge Developers 相關的全部條款約束。**
+
+**1. 背景**
+
+Longbridge AI Technology Pte. Ltd. 及其關聯公司（統稱"**Longbridge**"）通過封裝行情數據、賬户功能及相關服務，並以 CLI 工具、MCP 集成以及其他開發者工具和服務的形式提供給用户（統稱"**Longbridge Developers**"）。
+
+您可根據自身需要訪問和調用相關接口，並將其與所選第三方 AI 終端或應用程序（包括但不限於 OpenClaw、Claude Code、Cursor 及類似工具）集成（"**Third-Party AI Terminals**"）。安裝併成功連接後，用户可通過此類第三方終端或應用程序與 Longbridge Platform 和/或其平台賬户或證券賬户（如適用）進行交互。
+
+本授權書規範：（a）您所選擇的賬户數據在相關 Longbridge 集團實體之間，以及與相關 Third-Party AI Terminals 之間的共享；以及（b）您通過 Third-Party AI Terminals 發出的指令被視為您本人指令、用於執行證券交易的條款。
+
+**2. 數據共享授權及共享目的**
+
+**2.1 已授權數據範圍**
+
+本授權書所涵蓋的數據類別如下文及/或 OAuth 授權頁面 "Quotes Permission" 部分所示，以您的選擇為準。除非另有説明，與證券交易相關的數據一般由 Long Bridge Securities Pte. Ltd.（"**Longbridge Securities**"）共享給 Longbridge，其他數據則由 Longbridge Platform（定義見 Longbridge Platform 條款與條件）共享給 Longbridge。
+
+可能可用的數據類別包括以下各項，訪問權限按功能逐項授予，取決於您在相關頁面所選功能：
+
+1. Watchlist —— 管理用户自選股清單（列表 / 創建 / 更新 / 刪除），以及檢索特定自選股清單中所包含的證券，用於展示和維護。
+
+2. Trade Execution —— 買入、賣出或任何其他與交易執行相關的操作。
+
+3. Trade Order Lookup —— 涵蓋下單後的訂單生命週期與執行能力，包括訂單詳情、當日 / 歷史訂單查詢、當日 / 歷史成交記錄查詢，並在下單前提供最大可購買數量的估算。
+
+4. News & Filings —— 獲取股票新聞。
+
+5. Account & Positions —— 提供賬户資產與現金信息的只讀訪問，包括基金持倉、股票持倉、賬户現金餘額以及現金流歷史，用於投資組合概覽、持倉展示與對賬分析。
+
+6. Market Sentiment —— 查詢跨股票市場的 "Market Temperature"（類似恐懼指數的情緒温度計），包括當前及歷史讀數，用於情緒測量、趨勢可視化和對比分析。
+
+不時可能提供的任何其他數據類別。
+
+**2.2 與 Third-Party AI Terminals 的進一步共享**
+
+通過授予本授權，您確認並同意您在此向 Longbridge 授予的授權可在實現 Longbridge Developers 目的所必需的範圍內，並嚴格依照 PDPA，進一步與您部署的 Third-Party AI Terminals 共享。每個此類 Third-Party AI Terminals 須就其向您提供的 AI 服務負責，並獨立承擔其遵守適用法律法規（包括 PDPA）的責任。
+
+您確認 Longbridge 不控制 Third-Party AI Terminals 的數據實踐，您應在使用前查閲任何 Third-Party AI Terminals 的隱私政策。
+
+**2.3 共享目的**
+
+根據您上述選擇共享的數據將專門用於實現 Longbridge Developer 的功能。未經您另行同意，不會出於任何其他目的共享任何數據。
+
+**2.4 數據保護、訪問控制與合規**
+
+所有數據收集、存儲和處理活動均依據《新加坡 2012 年個人數據保護法令》（"**PDPA**"）以及其他適用的數據保護法規進行。Longbridge 僅在為實現本授權書所述目的所需期間，或在適用法律要求的期間內保留您的數據。您有權撤回同意、訪問您的數據以及請求更正不準確的數據，在各種情形下均依據 PDPA 進行。您可隨時通過在 Longbridge 平台內更新設置撤回本授權書。撤回自將來生效，不會影響在撤回生效日期之前已提交或已執行的指令。您可隨時通過平台設置或 Longbridge 提供的其他指定方式撤銷或斷開 Third-Party AI Terminal 的訪問。出於安全、系統保護、運營、合規或風險管理目的之合理必要情形下，某些訪問或功能可能被暫停、限制或終止。
+
+**3. 通過 Third-Party AI Terminals 發出指令的性質與效力（適用時）**
+
+您確認並同意，當您通過 Third-Party AI Terminals 發出指令，且該等指令應被傳輸至 Longbridge Securities 並由其執行時：
+
+Longbridge 僅作為 Longbridge Developers 的開發者。Longbridge 不控制、不審查、不背書，亦不就任何 Third-Party AI Terminal 所生成的內容、指令、建議或輸出承擔任何責任，包括因此產生的任何交易決策或結果。您所選擇的 Third-Party AI Terminal 是向您提供 AI 服務的責任方，您仍須在採取任何行動之前獨立評估並驗證 Third-Party AI Terminal 所提供的任何信息或建議。
+
+Third-Party AI Terminal 代表您將指令傳輸至 Longbridge Securities 以供執行，但其自身不會就任何指令進行發起、修改、解讀或行使任何自由裁量權。每條通過 Third-Party AI Terminal 傳輸的指令必須由您通過明確且有意識的用户操作發起。未經您輸入和確認，不會自動生成、觸發或執行任何指令。
+
+任何 Third-Party AI Terminal 未曾、目前不構成、且不會構成任何 Longbridge 集團實體或您個人的代理人、代表、投資顧問或決策實體。
+
+本授權書所述的證券服務及經紀職能由 Longbridge Securities 提供，該公司為受 Monetary Authority of Singapore 監管的資本市場服務牌照持有人。
+
+Longbridge Securities 嚴格按照您的授權執行指令，僅以執行為基礎，不提供投資建議，亦不行使自由裁量權。
+
+**通過授予本授權書，您明確允許您所選擇的 Third-Party AI Terminal 代表您向 Longbridge Securities 提交交易指令。該等指令一經確認和傳輸，應被視為您本人向 Longbridge Securities 發出的指令，並在執行後對您具有約束力。每條指令均源自您本人，且僅可歸因於您作為賬户持有人。您同意，Longbridge Securities 有權根據該等指令採取行動，除登錄時已進行的身份驗證之外，無需進一步驗證您的身份。**
+
+**4. 風險確認**
+
+您確認並接受以下風險：
+
+投資價值可能漲跌，過往表現不代表未來結果。
+
+通過 Third-Party AI Terminal 代表您向 Longbridge 傳輸的指令在執行後對您具有約束力。Longbridge 對因您所授權的指令（包括通過任何 Third-Party AI Terminal 傳輸的指令）所產生的任何損失不承擔責任。
+
+無論使用何種界面，您均須獨自負責在提交所有指令之前對其準確性進行審查和驗證。
+
+Third-Party AI Terminal 在理解或傳輸指令時可能出錯。您應在授權任何指令之前始終確認其細節。
+
+Third-Party Terminals 作為提供 AI 終端服務的實體，在收集和處理您的數據方面有義務遵守 PDPA 及所有其他適用的新加坡法律。您確認 Longbridge 不控制 Third-Party Terminals 的數據實踐，您應在使用前查閲任何第三方 AI 終端的隱私政策。
+
+**5. 一般條款**
+
+本授權書受新加坡法律管轄並據其解釋。任何由本授權書產生或與本授權書相關的爭議均應受新加坡法院專屬管轄。
+
+本授權書補充但不替代 [Longbridge Platform Terms and Conditions](https://support.longbridge.sg/topics/us-trade/user-agreement?locale=en)、[Privacy Policy](https://support.longbridge.sg/topics/Other/privacy-policy?locale=en) 以及其他相關條款或協議。請仔細閲讀並徹底理解上述文件及本聲明的內容，以做出知情的授權。
+
+Longbridge 保留不時修訂本授權書的權利。重大變更將提前通知您，並在適用法律要求時需要您重新確認。
+
+如本授權書的任何條款被認定為無效或不可執行，其餘條款應繼續完全有效。

--- a/docs/zh-HK/docs/market/_category_.json
+++ b/docs/zh-HK/docs/market/_category_.json
@@ -1,7 +1,7 @@
 {
   "label": "市場",
   "collapsible": true,
-  "collapsed": true,
+  "collapsed": false,
   "link": null,
   "position": 3.7
 }


### PR DESCRIPTION
## Summary

- Add `docs/{en,zh-CN,zh-HK}/docs/legal/` directory with `_category_.json` (position 8, collapsed)
- Add HK and SG versions of User Data Authorisation and Acknowledgement in three languages (6 files total)
- Add links in `AppFooter.vue` Legal section pointing to the two new pages
- Add i18n translation keys (`footer.dataAuthorisationHK` / `footer.dataAuthorisationSG`) for all three locales
- Use `sidebar_label` for shorter sidebar display names

## Test plan

- [ ] Sidebar shows "Legal" section (collapsed) with "Data Authorisation (HK)" and "Data Authorisation (SG)"
- [ ] Each page renders the full legal text correctly in all three languages
- [ ] Footer Legal section shows two new links; clicking navigates to the correct pages
- [ ] `localePath()` correctly prefixes `/zh-CN/` and `/zh-HK/` for non-English locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)