### PR TITLE
cn 版放出 MCP 页面并修复翻页指向不可访问页面

### DIFF
--- a/region.config.ts
+++ b/region.config.ts
@@ -39,6 +39,9 @@ export const regionConfig: Record<string, RegionConfig> = {
       '**/docs/cli/install.md',
       '**/docs/cli/release-notes.md',
 
+      // MCP
+      '**/docs/mcp.md',
+
       // AI Skills
       '**/skill/**',
     ],


### PR DESCRIPTION
## 变更概要
- `region.config.ts`: cn region `includePages` 白名单添加 `**/docs/mcp.md`
- `AppNav.vue`: 从 `CN_HIDDEN_KEYS` 中移除 `mcp`，cn 版顶部导航栏显示 MCP 入口
- 三语言 `mcp.md`: 添加 `prev: false` / `next: false` frontmatter，禁用底部翻页导航

## 风险分析
无显著风险（纯配置变更 + frontmatter）

## 验证状态
- 本地 VITE_REGION=cn dev server 验证：导航显示 MCP、翻页已消除
- 线上海外版确认同样存在翻页问题（Next Page -> Overview），此修复一并解决