### PR TITLE
cn 版放出 MCP 页面并修复翻页指向不可访问页面

### DIFF
--- a/docs/.vitepress/theme/components/AppNav.vue
+++ b/docs/.vitepress/theme/components/AppNav.vue
@@ -50,7 +50,7 @@ const APP_NAV_DEF = [
 
 const isCnDomain = import.meta.env.VITE_REGION === 'cn'
 
-const CN_HIDDEN_KEYS = new Set(['pricing', 'docs', 'features', 'mcp'])
+const CN_HIDDEN_KEYS = new Set(['pricing', 'docs', 'features'])
 
 const navLinks = computed(() =>
   APP_NAV_DEF.filter((n) => !isCnDomain || !CN_HIDDEN_KEYS.has(n.key)).map((n) => ({

--- a/docs/en/docs/mcp.md
+++ b/docs/en/docs/mcp.md
@@ -3,6 +3,8 @@ title: MCP
 id: mcp
 slug: /mcp
 sidebar: false
+prev: false
+next: false
 ---
 
 # Longbridge MCP Service

--- a/docs/zh-CN/docs/mcp.md
+++ b/docs/zh-CN/docs/mcp.md
@@ -3,6 +3,8 @@ title: MCP
 id: mcp
 slug: /mcp
 sidebar: false
+prev: false
+next: false
 ---
 
 # Longbridge MCP 服务

--- a/docs/zh-HK/docs/mcp.md
+++ b/docs/zh-HK/docs/mcp.md
@@ -3,6 +3,8 @@ title: MCP
 id: mcp
 slug: /mcp
 sidebar: false
+prev: false
+next: false
 ---
 
 # Longbridge MCP 服務


### PR DESCRIPTION
## 变更概要
- `region.config.ts`: cn region includePages 白名单添加 MCP 页面
- `AppNav.vue`: 从 CN_HIDDEN_KEYS 中移除 mcp，cn 版顶部导航栏显示 MCP 入口
- 三语言 mcp.md: 添加 prev/next: false frontmatter，禁用底部翻页导航

## 风险分析
无显著风险（纯配置变更 + frontmatter）

## 验证状态
- 本地 VITE_REGION=cn dev server 验证：导航显示 MCP、翻页已消除
- 线上海外版确认同样存在翻页问题（Next Page -> Overview），此修复一并解决