### PR TITLE
docs(cli): v0.22.0 CLI docs — short-trades, compare, top-movers, screener, rank

### DIFF
--- a/docs/en/docs/cli/derivatives/short-positions.md
+++ b/docs/en/docs/cli/derivatives/short-positions.md
@@ -6,7 +6,12 @@ sidebar_position: 3
 
 # longbridge short-positions
 
-US stock short selling data — short interest, short ratio, days to cover, and average daily volume. Only supports US-listed stocks and ETFs. Records are updated bi-monthly by FINRA.
+Short selling position data — short ratio, short share count, and related metrics. Supports both HK and US stocks; the market is auto-detected from the symbol suffix.
+
+- **HK**: HKEX daily data
+- **US**: FINRA bi-monthly data
+
+Add `--trades` to switch to daily short sale volume (distinct from outstanding positions).
 
 <QuotePermission command="short-positions" />
 
@@ -28,14 +33,58 @@ Short Selling Data — TSLA.US
 
 ## Examples
 
-### View short interest history
+### View US short interest history
 
 ```bash
 longbridge short-positions TSLA.US
 longbridge short-positions AAPL.US --count 50
 ```
 
-Returns up to 100 records newest first. Each row shows the settlement date, short ratio (short shares ÷ float), number of short shares, average daily volume, days-to-cover ratio, and closing price on that date.
+Returns up to 100 records newest first. Each row shows the settlement date, short ratio (short shares ÷ float), number of short shares, average daily volume, days-to-cover ratio, and closing price.
+
+### View HK short positions
+
+```bash
+longbridge short-positions 700.HK
+longbridge short-positions 700.HK --count 30
+```
+
+```
+Short Positions — 700.HK
+
+| date       | rate% | amount       | balance          | close  |
+|------------|-------|--------------|------------------|--------|
+| 2026-05-19 | 1.45% | 2,748,900    | 1,256,859,880.00 | 455.20 |
+```
+
+HK fields: settlement date, short ratio, daily short sale amount, outstanding balance, and closing price.
+
+### View daily short sale volume (--trades)
+
+```bash
+longbridge short-positions AAPL.US --trades
+longbridge short-positions 700.HK --trades
+```
+
+US (--trades):
+
+```
+Short Trades — AAPL.US
+
+| date       | rate%  | nus_amount | ny_amount | total_amount |
+|------------|--------|------------|-----------|--------------|
+| 2026-05-18 | 25.61% | 2,179,682  | 0         | 8,510,570    |
+```
+
+HK (--trades):
+
+```
+Short Trades — 700.HK
+
+| date       | rate%  | amount    | balance          | total_amount |
+|------------|--------|-----------|------------------|--------------|
+| 2026-05-18 | 10.65% | 3,592,700 | 1,657,732,820.00 | 33,736,701   |
+```
 
 ### Machine-readable output
 
@@ -60,9 +109,11 @@ longbridge short-positions NVDA.US --format json
 
 | Flag | Description |
 |------|-------------|
+| `--trades` | Show daily short sale volume instead of position balance |
 | `--count` | Number of records (1–100, default: 20) |
 | `--format` | Output format: `table` (default) or `json` |
 
 ## Requirements
 
-US market data subscription required. Only works for US-listed stocks and ETFs.
+- US: US market data subscription required. Only works for US-listed stocks and ETFs.
+- HK: HK market data subscription required.

--- a/docs/en/docs/cli/derivatives/short-trades.md
+++ b/docs/en/docs/cli/derivatives/short-trades.md
@@ -1,0 +1,91 @@
+---
+title: 'short-trades'
+sidebar_label: 'short-trades'
+sidebar_position: 4
+---
+
+# longbridge short-trades
+
+Daily short sale volume — unlike `short-positions` (outstanding balance), this command shows the actual short selling transactions that occurred each day. Supports US stocks (FINRA/Nasdaq) and HK stocks (HKEX). Market is auto-detected from the symbol suffix.
+
+<QuotePermission command="short-trades" />
+
+## Basic Usage
+
+```bash
+longbridge short-trades AAPL.US
+```
+
+```
+Short Trades — AAPL.US
+Updated: 2026-05-18T04:00:00Z
+
+| date                     | rate%  | nus_amount | ny_amount | total_amount | close   |
+|--------------------------|--------|------------|-----------|--------------|---------|
+| 2026-05-18T04:00:00Z    | 25.61% | 2,179,682  | 0         | 8,510,570    | 297.840 |
+| 2026-05-17T04:00:00Z    | 36.43% | 5,748,485  | 0         | 15,778,974   | 300.230 |
+```
+
+## Examples
+
+### View US daily short sale volume
+
+```bash
+longbridge short-trades AAPL.US
+longbridge short-trades AAPL.US --count 30
+```
+
+US field reference:
+
+| Field | Description |
+|-------|-------------|
+| `date` | Trading date (with timezone) |
+| `rate%` | Short volume as a percentage of total daily volume |
+| `nus_amount` | Short volume on national trading systems (NUS) |
+| `ny_amount` | Short volume on NYSE |
+| `total_amount` | Total short volume for the day |
+| `close` | Closing price for the day |
+
+### View HK daily short sale volume
+
+```bash
+longbridge short-trades 700.HK
+longbridge short-trades 700.HK --count 30
+```
+
+```
+Short Trades — 700.HK
+Updated: 2026-05-18T16:00:00Z
+
+| date                     | rate%  | amount    | balance          | total_amount | close |
+|--------------------------|--------|-----------|------------------|--------------|-------|
+| 2026-05-18T16:00:00Z    | 10.65% | 3,592,700 | 1,657,732,820.00 | 33,736,701   | 460.0 |
+```
+
+HK field reference:
+
+| Field | Description |
+|-------|-------------|
+| `date` | Trading date (with timezone) |
+| `rate%` | Short volume as a percentage of total daily volume |
+| `amount` | Short shares sold for the day |
+| `balance` | Outstanding short selling balance (HKD) |
+| `total_amount` | Total market shares traded for the day |
+| `close` | Closing price for the day |
+
+### Difference from short-positions
+
+- `short-trades`: actual short sale transactions that happened each day (flow)
+- `short-positions`: outstanding short position balance at a point in time (stock), updated bi-monthly for US stocks
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--count` | Number of records (1–100, default: 20) |
+| `--format` | Output format: `table` (default) or `json` |
+
+## Requirements
+
+- US: US market data subscription required.
+- HK: HK market data subscription required.

--- a/docs/en/docs/cli/fundamentals/compare.md
+++ b/docs/en/docs/cli/fundamentals/compare.md
@@ -1,0 +1,73 @@
+---
+title: 'compare'
+sidebar_label: 'compare'
+sidebar_position: 18
+---
+
+# longbridge compare
+
+Cross-stock valuation comparison (PE/PB/PS/market cap/close price/ROE). When no comparison symbols are specified, the server automatically selects peers from the same industry.
+
+## Basic Usage
+
+```bash
+longbridge compare AAPL.US
+```
+
+```
+Valuation Comparison
+
+| symbol  | name      | market_value | close    | pe    | pb    | ps    | roe    |
+|---------|-----------|--------------|----------|-------|-------|-------|--------|
+| AAPL.US | Apple     | $3.01T       | 205.10   | 31.2  | 45.2  | 7.8   | 136.5% |
+| MSFT.US | Microsoft | $3.12T       | 420.30   | 35.8  | 12.1  | 12.3  | 35.2%  |
+```
+
+When no peers are specified, the system automatically selects representative stocks from the same industry.
+
+## Examples
+
+### Auto-select industry peers
+
+```bash
+longbridge compare AAPL.US
+```
+
+The system selects industry peers automatically based on the sector classification of the primary symbol.
+
+### Specify comparison symbols
+
+```bash
+longbridge compare AAPL.US MSFT.US GOOGL.US
+```
+
+Supports up to 5 stocks (including the primary symbol) for side-by-side comparison.
+
+### HK stocks with currency conversion
+
+```bash
+longbridge compare 700.HK 9988.HK --currency HKD
+```
+
+Use `--currency` to unify market cap and price units when comparing across markets.
+
+### JSON output
+
+```bash
+longbridge compare TSLA.US RIVN.US --format json
+```
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `symbol` | Primary symbol (required) |
+| `[others...]` | Comparison symbols (optional, up to 4) |
+| `--currency` | Normalise to a single currency: `USD`, `HKD`, or `CNY` |
+| `--format` | Output format: `table` (default) or `json` |
+
+## Notes
+
+- When comparing across markets (e.g. US vs HK), use `--currency` to avoid FX distortions
+- PE, PB, PS use TTM (trailing twelve months) data
+- ROE is based on the most recent reporting period

--- a/docs/en/docs/cli/market-data/rank.md
+++ b/docs/en/docs/cli/market-data/rank.md
@@ -1,0 +1,88 @@
+---
+title: 'rank'
+sidebar_label: 'rank'
+sidebar_position: 20
+---
+
+# longbridge rank
+
+LB popularity rankings — a composite score of trading activity, community discussion, watchlist additions, and other signals. Without `--key`, lists all available rank categories. With `--key`, shows the ranked stock list for that category.
+
+<QuotePermission command="rank" />
+
+## Basic Usage
+
+```bash
+longbridge rank
+```
+
+```
+Rank Categories
+
+Total Heat:
+  ib_hot_all-us   US stocks
+  ib_hot_all-hk   HK stocks
+  ib_hot_all-cn   A-shares
+
+Heat Rising:
+  ib_hot_up-us    US stocks
+  ib_hot_up-hk    HK stocks
+  ib_hot_up-cn    A-shares
+
+Heat Falling:
+  ib_hot_down-us  US stocks
+  ib_hot_down-hk  HK stocks
+  ib_hot_down-cn  A-shares
+```
+
+## Examples
+
+### View US total heat ranking
+
+```bash
+longbridge rank --key ib_hot_all-us
+```
+
+```
+Rank — ib_hot_all-us
+
+| # | symbol  | name          | last_done | chg     | inflow          |
+|---|---------|---------------|-----------|---------|-----------------|
+| 1 | MU.US   | Micron        | 698.74    | +4.76%  | -347,041,642    |
+| 2 | NVDA.US | NVIDIA        | 131.80    | +3.21%  | +1,234,567,890  |
+| 3 | AAPL.US | Apple         | 205.10    | -0.42%  | +567,890,123    |
+```
+
+### View HK total heat ranking
+
+```bash
+longbridge rank --key ib_hot_all-hk
+```
+
+### View heat-rising ranking (top 20)
+
+```bash
+longbridge rank --key ib_hot_up-us --count 20
+```
+
+### List all categories
+
+```bash
+longbridge rank
+```
+
+Without `--key`, lists all available rank keys that can be passed directly to `--key`.
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--key` | Rank category key (from the no-args output) |
+| `--market` | Market filter for the category list (default: `US`) |
+| `--count` | Number of results (default: 20) |
+| `--format` | Output format: `table` (default) or `json` |
+
+## Notes
+
+- Rankings are a composite of trading volume, community discussion, watchlist additions, and more — not simply price performance
+- `inflow` is net capital flow for the day (positive = inflow, negative = outflow)

--- a/docs/en/docs/cli/market-data/top-movers.md
+++ b/docs/en/docs/cli/market-data/top-movers.md
@@ -1,0 +1,72 @@
+---
+title: 'top-movers'
+sidebar_label: 'top-movers'
+sidebar_position: 19
+---
+
+# longbridge top-movers
+
+Stocks whose price movement exceeds their 20-day standard deviation. The system automatically links related news to explain the reason behind each move. Unlike `anomaly` (pure technical signal), `top-movers` focuses on price moves with news context.
+
+<QuotePermission command="top-movers" />
+
+## Basic Usage
+
+```bash
+longbridge top-movers
+```
+
+```
+Top Movers — US
+
+TSLA  Tesla  -3.88%  [Automobile Manufacturers]
+  Alert: Move exceeds 20-day average
+  Related news: "Tesla Q1 deliveries miss estimates..."
+
+NVDA  NVIDIA  +4.21%  [Semiconductor Manufacturers]
+  Alert: Move exceeds 20-day average
+  Related news: "NVIDIA announces next-gen GPU architecture..."
+```
+
+## Examples
+
+### View US movers
+
+```bash
+longbridge top-movers
+longbridge top-movers --market US
+```
+
+Default market is US. Results are sorted by heat (relevance/activity).
+
+### View HK movers
+
+```bash
+longbridge top-movers --market HK
+```
+
+### Sort by time and increase result count
+
+```bash
+longbridge top-movers --market US --sort time --count 50
+```
+
+### Sort by price change
+
+```bash
+longbridge top-movers --market US --sort change
+```
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--market` | Market: `HK`, `US`, `CN`, `SG` (default: `US`) |
+| `--sort` | Sort order: `hot` (default), `time`, or `change` |
+| `--count` | Number of results (default: 20) |
+| `--format` | Output format: `table` (default) or `json` |
+
+## Notes
+
+- `top-movers` links related news, making it useful for understanding the context behind a move; `anomaly` focuses on pure technical signals
+- The volatility threshold is based on the 20-day historical standard deviation

--- a/docs/en/docs/cli/research/screener.md
+++ b/docs/en/docs/cli/research/screener.md
@@ -1,0 +1,116 @@
+---
+title: 'screener'
+sidebar_label: 'screener'
+sidebar_position: 4
+---
+
+# longbridge screener
+
+Stock screener — filter stocks using preset strategies or custom indicator conditions.
+
+## Basic Usage
+
+```bash
+longbridge screener strategies
+```
+
+```
+Recommended Strategies
+
+| id | name                    | market | description                              |
+|----|-------------------------|--------|------------------------------------------|
+| 1  | High-Yield Defensive    | HK     | Dividend yield > 5%, PE < 15             |
+| 2  | Accelerating Growth     | US     | Revenue growth > 30%, ROE > 20%          |
+| 42 | Undervalued Blue Chips  | HK     | PB < 1.5, market cap > HKD 10B           |
+```
+
+## Examples
+
+### Workflow A — Use a preset strategy
+
+**Step 1: List available strategies**
+
+```bash
+longbridge screener strategies
+```
+
+**Step 2: Inspect a strategy's filter conditions**
+
+```bash
+longbridge screener strategies --id 42
+```
+
+```
+Strategy #42: Undervalued Blue Chips
+
+Filters:
+  filter_pb: 0 ~ 1.5
+  filter_marketcap: 100 ~ (unlimited)
+  filter_divyld: 2 ~ (unlimited)
+```
+
+**Step 3: Run the strategy**
+
+```bash
+longbridge screener search --strategy-id 42
+```
+
+### Workflow B — Custom filter conditions
+
+**Step 1: List available indicators**
+
+```bash
+longbridge screener indicators
+```
+
+```
+Available Indicators
+
+Valuation:
+  filter_pe          P/E ratio
+  filter_pb          P/B ratio
+  filter_ps          P/S ratio
+  filter_marketcap   Market cap (100M)
+  filter_divyld      Dividend yield (%)
+
+Growth:
+  filter_rev_growth  Revenue growth (%)
+  filter_roe         Return on equity (%)
+  ...
+```
+
+**Step 2: Run a custom screen**
+
+```bash
+longbridge screener search --market HK --filter filter_marketcap:100:1000 --filter filter_divyld:3:
+```
+
+Filter format: `<key>:<min>:<max>`. Omit `min` or `max` to leave that side unbounded.
+
+### View my saved strategies
+
+```bash
+longbridge screener strategies --mine
+```
+
+Lists your saved custom strategies.
+
+## Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `strategies` | List recommended strategies (add `--mine` for custom strategies) |
+| `strategies --id <id>` | Show filter conditions for a specific strategy |
+| `search` | Run a screen (`--strategy-id` or `--filter`) |
+| `indicators` | List all available filter indicators |
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--mine` | Show my saved strategies (with `strategies`) |
+| `--id` | View filter conditions for a specific strategy (with `strategies`) |
+| `--strategy-id` | Run the specified strategy (with `search`) |
+| `--market` | Target market: `HK`, `US`, `CN`, `SG` (with `search`) |
+| `--filter` | Custom filter condition, format `<key>:<min>:<max>`, repeatable |
+| `--format` | Output format: `table` (default) or `json` |

--- a/docs/en/docs/cli/research/shareholder.md
+++ b/docs/en/docs/cli/research/shareholder.md
@@ -34,3 +34,50 @@ longbridge shareholder TSLA.US --format json
 ```
 
 Lists the largest shareholders by ownership percentage, including both institutional investors and individual insiders.
+
+### View top 20 shareholders (--top)
+
+```bash
+longbridge shareholder AAPL.US --top
+```
+
+```
+Top 20 Shareholders — AAPL.US
+
+Period: Latest
+
+| shareholder                    | type        | % shares | chg shares | filing_date |
+|--------------------------------|-------------|----------|------------|-------------|
+| The Vanguard Group, Inc.       | Institution | 9.71%    | +0.01%     | 2025/12/31  |
+| BlackRock, Inc.                | Institution | 7.75%    | -0.06%     | 2026/03/31  |
+| ...
+
+Use --object-id <id> to view holding detail for a specific shareholder.
+```
+
+`--top` mode spans multiple reporting periods, includes institutions, individuals, and insiders, and displays the shareholder type (Institution / Individual / Insider).
+
+### View shareholder holding detail (--object-id)
+
+```bash
+longbridge shareholder AAPL.US --object-id 148057
+```
+
+```
+Shareholder Detail: The Vanguard Group, Inc.
+
+Trading History:
+
+Period: Past 1 Year
+  accum_buy: 0.00  accum_sell: 0.00
+```
+
+`--object-id` accepts a shareholder ID from `--top` output and returns that shareholder's historical position changes and trading activity.
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--top` | Show top 20 shareholders across multiple reporting periods, including institutions and individuals |
+| `--object-id` | View holding detail for a specific shareholder (ID from `--top` output) |
+| `--format` | Output format: `table` (default) or `json` |

--- a/docs/zh-CN/docs/cli/derivatives/short-positions.md
+++ b/docs/zh-CN/docs/cli/derivatives/short-positions.md
@@ -6,7 +6,12 @@ sidebar_position: 3
 
 # longbridge short-positions
 
-美股做空数据——空头比例、空头股数、需几日平仓（days-to-cover）及日均成交量。仅支持美股及 ETF，数据由 FINRA 每两周更新一次。
+做空持仓数据——空头比例、空头股数及相关指标。支持港股和美股，市场根据代码后缀自动识别。
+
+- **港股**：港交所每日数据
+- **美股**：FINRA 每两周更新一次
+
+加 `--trades` 可切换为每日沽空成交量（区别于持仓余额）。
 
 <QuotePermission command="short-positions" />
 
@@ -28,7 +33,7 @@ Short Selling Data — TSLA.US
 
 ## 示例
 
-### 查看做空历史数据
+### 查看美股做空历史数据
 
 ```bash
 longbridge short-positions TSLA.US
@@ -36,6 +41,50 @@ longbridge short-positions AAPL.US --count 50
 ```
 
 最多返回 100 条记录，按日期倒序排列。每行包含结算日、空头比例（空头股数 ÷ 流通股数）、空头股数、日均成交量、平仓天数及当日收盘价。
+
+### 查看港股做空持仓
+
+```bash
+longbridge short-positions 700.HK
+longbridge short-positions 700.HK --count 30
+```
+
+```
+Short Positions — 700.HK
+
+| date       | rate% | amount       | balance          | close  |
+|------------|-------|--------------|------------------|--------|
+| 2026-05-19 | 1.45% | 2,748,900    | 1,256,859,880.00 | 455.20 |
+```
+
+港股返回字段：结算日、空头比例、当日沽空金额、未平仓余额及收盘价。
+
+### 查看每日沽空成交量（--trades）
+
+```bash
+longbridge short-positions AAPL.US --trades
+longbridge short-positions 700.HK --trades
+```
+
+美股（--trades）：
+
+```
+Short Trades — AAPL.US
+
+| date       | rate%  | nus_amount | ny_amount | total_amount |
+|------------|--------|------------|-----------|--------------|
+| 2026-05-18 | 25.61% | 2,179,682  | 0         | 8,510,570    |
+```
+
+港股（--trades）：
+
+```
+Short Trades — 700.HK
+
+| date       | rate%  | amount    | balance          | total_amount |
+|------------|--------|-----------|------------------|--------------|
+| 2026-05-18 | 10.65% | 3,592,700 | 1,657,732,820.00 | 33,736,701   |
+```
 
 ### 机器可读格式
 
@@ -60,9 +109,11 @@ longbridge short-positions NVDA.US --format json
 
 | 参数 | 说明 |
 |------|------|
+| `--trades` | 显示每日沽空成交量而非持仓余额 |
 | `--count` | 返回条数（1–100，默认：20） |
 | `--format` | 输出格式：`table`（默认）或 `json` |
 
 ## 权限要求
 
-需要美股行情权限，仅支持美股及 ETF。
+- 美股：需要美股行情权限，仅支持美股及 ETF
+- 港股：需要港股行情权限

--- a/docs/zh-CN/docs/cli/derivatives/short-trades.md
+++ b/docs/zh-CN/docs/cli/derivatives/short-trades.md
@@ -1,0 +1,91 @@
+---
+title: 'short-trades'
+sidebar_label: 'short-trades'
+sidebar_position: 4
+---
+
+# longbridge short-trades
+
+每日沽空成交量——区别于 `short-positions`（持仓数据），此命令显示每日实际发生的沽空交易量。支持美股（FINRA/纳斯达克）和港股（港交所）。市场根据代码后缀自动识别。
+
+<QuotePermission command="short-trades" />
+
+## 基本用法
+
+```bash
+longbridge short-trades AAPL.US
+```
+
+```
+Short Trades — AAPL.US
+Updated: 2026-05-18T04:00:00Z
+
+| date                     | rate%  | nus_amount | ny_amount | total_amount | close   |
+|--------------------------|--------|------------|-----------|--------------|---------|
+| 2026-05-18T04:00:00Z    | 25.61% | 2,179,682  | 0         | 8,510,570    | 297.840 |
+| 2026-05-17T04:00:00Z    | 36.43% | 5,748,485  | 0         | 15,778,974   | 300.230 |
+```
+
+## 示例
+
+### 查看美股每日沽空成交量
+
+```bash
+longbridge short-trades AAPL.US
+longbridge short-trades AAPL.US --count 30
+```
+
+美股字段说明：
+
+| 字段 | 说明 |
+|------|------|
+| `date` | 交易日（含时区） |
+| `rate%` | 沽空量占当日总成交量的比例 |
+| `nus_amount` | 全国交易系统（NUS）沽空股数 |
+| `ny_amount` | 纽交所（NYSE）沽空股数 |
+| `total_amount` | 当日总沽空股数 |
+| `close` | 当日收盘价 |
+
+### 查看港股每日沽空成交量
+
+```bash
+longbridge short-trades 700.HK
+longbridge short-trades 700.HK --count 30
+```
+
+```
+Short Trades — 700.HK
+Updated: 2026-05-18T16:00:00Z
+
+| date                     | rate%  | amount    | balance          | total_amount | close |
+|--------------------------|--------|-----------|------------------|--------------|-------|
+| 2026-05-18T16:00:00Z    | 10.65% | 3,592,700 | 1,657,732,820.00 | 33,736,701   | 460.0 |
+```
+
+港股字段说明：
+
+| 字段 | 说明 |
+|------|------|
+| `date` | 交易日（含时区） |
+| `rate%` | 沽空量占当日总成交量的比例 |
+| `amount` | 当日沽空股数 |
+| `balance` | 未平仓沽空余额（港元） |
+| `total_amount` | 市场当日总成交股数 |
+| `close` | 当日收盘价 |
+
+### 与 short-positions 的区别
+
+- `short-trades`：每日实际发生的沽空成交量（流量）
+- `short-positions`：某时点的未平仓沽空余额（存量），美股每两周更新
+
+## 参数
+
+| 参数 | 说明 |
+|------|------|
+| `--count` | 返回条数（1–100，默认：20） |
+| `--format` | 输出格式：`table`（默认）或 `json` |
+
+## 权限要求
+
+- 美股：需要美股行情权限
+- 港股：需要港股行情权限

--- a/docs/zh-CN/docs/cli/fundamentals/compare.md
+++ b/docs/zh-CN/docs/cli/fundamentals/compare.md
@@ -1,0 +1,73 @@
+---
+title: 'compare'
+sidebar_label: 'compare'
+sidebar_position: 18
+---
+
+# longbridge compare
+
+多股估值横向对比（PE/PB/PS/市值/收盘价/ROE）。不传对比股票时，服务端自动选取同行业标的。
+
+## 基本用法
+
+```bash
+longbridge compare AAPL.US
+```
+
+```
+Valuation Comparison
+
+| symbol  | name   | market_value | close    | pe    | pb    | ps    | roe    |
+|---------|--------|--------------|----------|-------|-------|-------|--------|
+| AAPL.US | 苹果   | $3.01T       | 205.10   | 31.2  | 45.2  | 7.8   | 136.5% |
+| MSFT.US | 微软   | $3.12T       | 420.30   | 35.8  | 12.1  | 12.3  | 35.2%  |
+```
+
+不指定对比标的时，系统自动从同行业中选取代表性标的进行对比。
+
+## 示例
+
+### 自动选取同行业标的
+
+```bash
+longbridge compare AAPL.US
+```
+
+系统根据行业归属自动选取同行业股票作为对比组，无需手动指定。
+
+### 指定对比标的
+
+```bash
+longbridge compare AAPL.US MSFT.US GOOGL.US
+```
+
+最多支持 5 只股票（含主标的）的横向对比。
+
+### 港股对比并指定货币
+
+```bash
+longbridge compare 700.HK 9988.HK --currency HKD
+```
+
+使用 `--currency` 统一市值、收盘价等货币单位，避免跨市场汇率干扰。
+
+### JSON 输出
+
+```bash
+longbridge compare TSLA.US RIVN.US --format json
+```
+
+## 参数
+
+| 参数 | 说明 |
+|------|------|
+| `symbol` | 主标的（必填） |
+| `[others...]` | 对比标的（可选，最多 4 个） |
+| `--currency` | 统一货币单位：`USD`、`HKD`、`CNY` |
+| `--format` | 输出格式：`table`（默认）或 `json` |
+
+## 注意事项
+
+- 跨市场对比（如美股 vs 港股）时，建议指定 `--currency` 统一单位
+- PE、PB、PS 为 TTM（过去 12 个月）数据
+- ROE 为最新报告期数据

--- a/docs/zh-CN/docs/cli/market-data/rank.md
+++ b/docs/zh-CN/docs/cli/market-data/rank.md
@@ -1,0 +1,88 @@
+---
+title: 'rank'
+sidebar_label: 'rank'
+sidebar_position: 20
+---
+
+# longbridge rank
+
+LB 人气排行榜，综合交易热度、社区讨论、关注度等多维指标。不传 `--key` 时列出所有排行榜分类；传入 `--key` 时显示该榜单的股票排名。
+
+<QuotePermission command="rank" />
+
+## 基本用法
+
+```bash
+longbridge rank
+```
+
+```
+Rank Categories
+
+Total Heat:
+  ib_hot_all-us   美股
+  ib_hot_all-hk   港股
+  ib_hot_all-cn   A 股
+
+Heat Rising:
+  ib_hot_up-us    美股
+  ib_hot_up-hk    港股
+  ib_hot_up-cn    A 股
+
+Heat Falling:
+  ib_hot_down-us  美股
+  ib_hot_down-hk  港股
+  ib_hot_down-cn  A 股
+```
+
+## 示例
+
+### 查看美股总热度排行
+
+```bash
+longbridge rank --key ib_hot_all-us
+```
+
+```
+Rank — ib_hot_all-us
+
+| # | symbol  | name    | last_done | chg     | inflow          |
+|---|---------|---------|-----------|---------|-----------------|
+| 1 | MU.US   | 美光科技 | 698.74    | +4.76%  | -347,041,642    |
+| 2 | NVDA.US | 英伟达   | 131.80    | +3.21%  | +1,234,567,890  |
+| 3 | AAPL.US | 苹果     | 205.10    | -0.42%  | +567,890,123    |
+```
+
+### 查看港股总热度排行
+
+```bash
+longbridge rank --key ib_hot_all-hk
+```
+
+### 查看热度上升榜（前 20）
+
+```bash
+longbridge rank --key ib_hot_up-us --count 20
+```
+
+### 查看所有分类
+
+```bash
+longbridge rank
+```
+
+不传 `--key` 时列出所有可用的排行榜 key，可直接复制用于 `--key` 参数。
+
+## 参数
+
+| 参数 | 说明 |
+|------|------|
+| `--key` | 排行榜 key（从无参数调用的输出中获取） |
+| `--market` | 市场筛选，用于无参数时的分类列表（默认：`US`） |
+| `--count` | 返回条数（默认：20） |
+| `--format` | 输出格式：`table`（默认）或 `json` |
+
+## 注意事项
+
+- 人气排行综合考量交易热度、社区讨论量、关注数等多维指标，与纯价格涨跌排行不同
+- `inflow` 为当日资金净流入（正值流入，负值流出）

--- a/docs/zh-CN/docs/cli/market-data/top-movers.md
+++ b/docs/zh-CN/docs/cli/market-data/top-movers.md
@@ -1,0 +1,72 @@
+---
+title: 'top-movers'
+sidebar_label: 'top-movers'
+sidebar_position: 19
+---
+
+# longbridge top-movers
+
+价格波动超过近 20 日标准差的异动股票。系统自动关联相关新闻解读异动原因，与 `anomaly` 命令（纯技术信号）不同，`top-movers` 侧重于有新闻背景的价格波动。
+
+<QuotePermission command="top-movers" />
+
+## 基本用法
+
+```bash
+longbridge top-movers
+```
+
+```
+Top Movers — US
+
+TSLA  特斯拉  -3.88%  [汽车制造商]
+  Alert: 波动超 20 日均值
+  Related news: "Tesla Q1 deliveries miss estimates..."
+
+NVDA  英伟达  +4.21%  [半导体厂商]
+  Alert: 波动超 20 日均值
+  Related news: "NVIDIA announces next-gen GPU architecture..."
+```
+
+## 示例
+
+### 查看美股异动
+
+```bash
+longbridge top-movers
+longbridge top-movers --market US
+```
+
+默认显示美股异动股票，按热度排序。
+
+### 查看港股异动
+
+```bash
+longbridge top-movers --market HK
+```
+
+### 按时间排序并增加返回数量
+
+```bash
+longbridge top-movers --market US --sort time --count 50
+```
+
+### 按涨跌幅排序
+
+```bash
+longbridge top-movers --market US --sort change
+```
+
+## 参数
+
+| 参数 | 说明 |
+|------|------|
+| `--market` | 市场：`HK`、`US`、`CN`、`SG`（默认：`US`） |
+| `--sort` | 排序方式：`hot`（热度，默认）、`time`（时间）、`change`（涨跌幅） |
+| `--count` | 返回条数（默认：20） |
+| `--format` | 输出格式：`table`（默认）或 `json` |
+
+## 注意事项
+
+- `top-movers` 关联新闻，适合理解异动背景；`anomaly` 侧重纯技术信号
+- 波动判断基于近 20 日历史波动标准差

--- a/docs/zh-CN/docs/cli/research/screener.md
+++ b/docs/zh-CN/docs/cli/research/screener.md
@@ -1,0 +1,116 @@
+---
+title: 'screener'
+sidebar_label: 'screener'
+sidebar_position: 4
+---
+
+# longbridge screener
+
+股票筛选工具，通过预设策略或自定义指标条件筛选股票。
+
+## 基本用法
+
+```bash
+longbridge screener strategies
+```
+
+```
+Recommended Strategies
+
+| id | name              | market | description                   |
+|----|-------------------|--------|-------------------------------|
+| 1  | 高股息防御型       | HK     | 股息率 > 5%，PE < 15          |
+| 2  | 成长加速型         | US     | 营收增速 > 30%，ROE > 20%     |
+| 42 | 低估值蓝筹         | HK     | PB < 1.5，市值 > 100 亿港元   |
+```
+
+## 示例
+
+### 工作流 A — 使用预设策略
+
+**第一步：获取策略列表**
+
+```bash
+longbridge screener strategies
+```
+
+**第二步：查看策略筛选条件**
+
+```bash
+longbridge screener strategies --id 42
+```
+
+```
+Strategy #42: 低估值蓝筹
+
+Filters:
+  filter_pb: 0 ~ 1.5
+  filter_marketcap: 100 ~ (unlimited)
+  filter_divyld: 2 ~ (unlimited)
+```
+
+**第三步：执行筛选**
+
+```bash
+longbridge screener search --strategy-id 42
+```
+
+### 工作流 B — 自定义条件
+
+**第一步：查看可用指标**
+
+```bash
+longbridge screener indicators
+```
+
+```
+Available Indicators
+
+Valuation:
+  filter_pe          市盈率 (PE)
+  filter_pb          市净率 (PB)
+  filter_ps          市销率 (PS)
+  filter_marketcap   市值（亿）
+  filter_divyld      股息率 (%)
+
+Growth:
+  filter_rev_growth  营收增速 (%)
+  filter_roe         净资产收益率 (%)
+  ...
+```
+
+**第二步：执行自定义筛选**
+
+```bash
+longbridge screener search --market HK --filter filter_marketcap:100:1000 --filter filter_divyld:3:
+```
+
+指标格式：`<key>:<min>:<max>`，省略 `min` 或 `max` 表示不限下/上限。
+
+### 查看我的策略
+
+```bash
+longbridge screener strategies --mine
+```
+
+显示已保存的自定义策略列表。
+
+## 子命令
+
+| 子命令 | 说明 |
+|--------|------|
+| `strategies` | 列出推荐策略（加 `--mine` 显示自定义策略） |
+| `strategies --id <id>` | 查看特定策略的筛选条件 |
+| `search` | 执行筛选（`--strategy-id` 或 `--filter`） |
+| `indicators` | 列出所有可用筛选指标 |
+
+## 参数
+
+| 参数 | 说明 |
+|------|------|
+| `--mine` | 显示我保存的策略（配合 `strategies` 使用） |
+| `--id` | 查看指定策略的条件（配合 `strategies` 使用） |
+| `--strategy-id` | 执行指定策略的筛选（配合 `search` 使用） |
+| `--market` | 筛选市场：`HK`、`US`、`CN`、`SG`（配合 `search` 使用） |
+| `--filter` | 自定义筛选条件，格式 `<key>:<min>:<max>`，可多次使用 |
+| `--format` | 输出格式：`table`（默认）或 `json` |

--- a/docs/zh-CN/docs/cli/research/shareholder.md
+++ b/docs/zh-CN/docs/cli/research/shareholder.md
@@ -34,3 +34,50 @@ longbridge shareholder TSLA.US --format json
 ```
 
 按持股比例列出最大股东，包括机构投资者和个人内部人士。
+
+### 查看前 20 大股东（--top）
+
+```bash
+longbridge shareholder AAPL.US --top
+```
+
+```
+Top 20 Shareholders — AAPL.US
+
+Period: Latest
+
+| shareholder                    | type        | % shares | chg shares | filing_date |
+|--------------------------------|-------------|----------|------------|-------------|
+| The Vanguard Group, Inc.       | Institution | 9.71%    | +0.01%     | 2025/12/31  |
+| BlackRock, Inc.                | Institution | 7.75%    | -0.06%     | 2026/03/31  |
+| ...
+
+Use --object-id <id> to view holding detail for a specific shareholder.
+```
+
+`--top` 模式覆盖多个报告期，包含机构、个人及内部人士，并显示股东类型（Institution / Individual / Insider）。
+
+### 查看特定股东持股详情（--object-id）
+
+```bash
+longbridge shareholder AAPL.US --object-id 148057
+```
+
+```
+Shareholder Detail: The Vanguard Group, Inc.
+
+Trading History:
+
+Period: Past 1 Year
+  accum_buy: 0.00  accum_sell: 0.00
+```
+
+`--object-id` 接受 `--top` 输出中的股东 ID，返回该股东历史持仓变化和买卖记录。
+
+## 参数
+
+| 参数 | 说明 |
+|------|------|
+| `--top` | 显示前 20 大股东，含机构和个人，跨多个报告期 |
+| `--object-id` | 查看特定股东持仓详情（ID 从 `--top` 输出获取） |
+| `--format` | 输出格式：`table`（默认）或 `json` |

--- a/docs/zh-HK/docs/cli/derivatives/short-positions.md
+++ b/docs/zh-HK/docs/cli/derivatives/short-positions.md
@@ -6,7 +6,12 @@ sidebar_position: 3
 
 # longbridge short-positions
 
-美股放空資料——空頭比例、空頭股數、平倉天數（days-to-cover）及日均成交量。僅支援美股及 ETF，資料由 FINRA 每兩週更新一次。
+放空持倉資料——空頭比例、空頭股數及相關指標。支援港股和美股，市場根據代碼後綴自動識別。
+
+- **港股**：港交所每日資料
+- **美股**：FINRA 每兩週更新一次
+
+加 `--trades` 可切換為每日沽空成交量（區別於持倉餘額）。
 
 <QuotePermission command="short-positions" />
 
@@ -28,7 +33,7 @@ Short Selling Data — TSLA.US
 
 ## 示例
 
-### 查看放空歷史資料
+### 查看美股放空歷史資料
 
 ```bash
 longbridge short-positions TSLA.US
@@ -36,6 +41,50 @@ longbridge short-positions AAPL.US --count 50
 ```
 
 最多返回 100 筆記錄，按日期倒序排列。每行包含結算日、空頭比例（空頭股數 ÷ 流通股數）、空頭股數、日均成交量、平倉天數及當日收盤價。
+
+### 查看港股放空持倉
+
+```bash
+longbridge short-positions 700.HK
+longbridge short-positions 700.HK --count 30
+```
+
+```
+Short Positions — 700.HK
+
+| date       | rate% | amount       | balance          | close  |
+|------------|-------|--------------|------------------|--------|
+| 2026-05-19 | 1.45% | 2,748,900    | 1,256,859,880.00 | 455.20 |
+```
+
+港股返回欄位：結算日、空頭比例、當日沽空金額、未平倉餘額及收盤價。
+
+### 查看每日沽空成交量（--trades）
+
+```bash
+longbridge short-positions AAPL.US --trades
+longbridge short-positions 700.HK --trades
+```
+
+美股（--trades）：
+
+```
+Short Trades — AAPL.US
+
+| date       | rate%  | nus_amount | ny_amount | total_amount |
+|------------|--------|------------|-----------|--------------|
+| 2026-05-18 | 25.61% | 2,179,682  | 0         | 8,510,570    |
+```
+
+港股（--trades）：
+
+```
+Short Trades — 700.HK
+
+| date       | rate%  | amount    | balance          | total_amount |
+|------------|--------|-----------|------------------|--------------|
+| 2026-05-18 | 10.65% | 3,592,700 | 1,657,732,820.00 | 33,736,701   |
+```
 
 ### 機器可讀格式
 
@@ -60,9 +109,11 @@ longbridge short-positions NVDA.US --format json
 
 | 參數 | 說明 |
 |------|------|
+| `--trades` | 顯示每日沽空成交量而非持倉餘額 |
 | `--count` | 返回筆數（1–100，預設：20） |
 | `--format` | 輸出格式：`table`（預設）或 `json` |
 
 ## 權限要求
 
-需要美股行情權限，僅支援美股及 ETF。
+- 美股：需要美股行情權限，僅支援美股及 ETF
+- 港股：需要港股行情權限

--- a/docs/zh-HK/docs/cli/derivatives/short-trades.md
+++ b/docs/zh-HK/docs/cli/derivatives/short-trades.md
@@ -1,0 +1,91 @@
+---
+title: 'short-trades'
+sidebar_label: 'short-trades'
+sidebar_position: 4
+---
+
+# longbridge short-trades
+
+每日沽空成交量——區別於 `short-positions`（持倉資料），此命令顯示每日實際發生的沽空交易量。支援美股（FINRA/納斯達克）和港股（港交所）。市場根據代碼後綴自動識別。
+
+<QuotePermission command="short-trades" />
+
+## 基本用法
+
+```bash
+longbridge short-trades AAPL.US
+```
+
+```
+Short Trades — AAPL.US
+Updated: 2026-05-18T04:00:00Z
+
+| date                     | rate%  | nus_amount | ny_amount | total_amount | close   |
+|--------------------------|--------|------------|-----------|--------------|---------|
+| 2026-05-18T04:00:00Z    | 25.61% | 2,179,682  | 0         | 8,510,570    | 297.840 |
+| 2026-05-17T04:00:00Z    | 36.43% | 5,748,485  | 0         | 15,778,974   | 300.230 |
+```
+
+## 示例
+
+### 查看美股每日沽空成交量
+
+```bash
+longbridge short-trades AAPL.US
+longbridge short-trades AAPL.US --count 30
+```
+
+美股欄位說明：
+
+| 欄位 | 說明 |
+|------|------|
+| `date` | 交易日（含時區） |
+| `rate%` | 沽空量佔當日總成交量的比例 |
+| `nus_amount` | 全國交易系統（NUS）沽空股數 |
+| `ny_amount` | 紐交所（NYSE）沽空股數 |
+| `total_amount` | 當日總沽空股數 |
+| `close` | 當日收盤價 |
+
+### 查看港股每日沽空成交量
+
+```bash
+longbridge short-trades 700.HK
+longbridge short-trades 700.HK --count 30
+```
+
+```
+Short Trades — 700.HK
+Updated: 2026-05-18T16:00:00Z
+
+| date                     | rate%  | amount    | balance          | total_amount | close |
+|--------------------------|--------|-----------|------------------|--------------|-------|
+| 2026-05-18T16:00:00Z    | 10.65% | 3,592,700 | 1,657,732,820.00 | 33,736,701   | 460.0 |
+```
+
+港股欄位說明：
+
+| 欄位 | 說明 |
+|------|------|
+| `date` | 交易日（含時區） |
+| `rate%` | 沽空量佔當日總成交量的比例 |
+| `amount` | 當日沽空股數 |
+| `balance` | 未平倉沽空餘額（港元） |
+| `total_amount` | 市場當日總成交股數 |
+| `close` | 當日收盤價 |
+
+### 與 short-positions 的區別
+
+- `short-trades`：每日實際發生的沽空成交量（流量）
+- `short-positions`：某時點的未平倉沽空餘額（存量），美股每兩週更新
+
+## 參數
+
+| 參數 | 說明 |
+|------|------|
+| `--count` | 返回筆數（1–100，預設：20） |
+| `--format` | 輸出格式：`table`（預設）或 `json` |
+
+## 權限要求
+
+- 美股：需要美股行情權限
+- 港股：需要港股行情權限

--- a/docs/zh-HK/docs/cli/fundamentals/compare.md
+++ b/docs/zh-HK/docs/cli/fundamentals/compare.md
@@ -1,0 +1,73 @@
+---
+title: 'compare'
+sidebar_label: 'compare'
+sidebar_position: 18
+---
+
+# longbridge compare
+
+多股估值橫向對比（PE/PB/PS/市值/收盤價/ROE）。不傳對比股票時，服務端自動選取同行業標的。
+
+## 基本用法
+
+```bash
+longbridge compare AAPL.US
+```
+
+```
+Valuation Comparison
+
+| symbol  | name   | market_value | close    | pe    | pb    | ps    | roe    |
+|---------|--------|--------------|----------|-------|-------|-------|--------|
+| AAPL.US | 蘋果   | $3.01T       | 205.10   | 31.2  | 45.2  | 7.8   | 136.5% |
+| MSFT.US | 微軟   | $3.12T       | 420.30   | 35.8  | 12.1  | 12.3  | 35.2%  |
+```
+
+不指定對比標的時，系統自動從同行業中選取代表性標的進行對比。
+
+## 示例
+
+### 自動選取同行業標的
+
+```bash
+longbridge compare AAPL.US
+```
+
+系統根據行業歸屬自動選取同行業股票作為對比組，無需手動指定。
+
+### 指定對比標的
+
+```bash
+longbridge compare AAPL.US MSFT.US GOOGL.US
+```
+
+最多支援 5 隻股票（含主標的）的橫向對比。
+
+### 港股對比並指定貨幣
+
+```bash
+longbridge compare 700.HK 9988.HK --currency HKD
+```
+
+使用 `--currency` 統一市值、收盤價等貨幣單位，避免跨市場匯率干擾。
+
+### JSON 輸出
+
+```bash
+longbridge compare TSLA.US RIVN.US --format json
+```
+
+## 參數
+
+| 參數 | 說明 |
+|------|------|
+| `symbol` | 主標的（必填） |
+| `[others...]` | 對比標的（可選，最多 4 個） |
+| `--currency` | 統一貨幣單位：`USD`、`HKD`、`CNY` |
+| `--format` | 輸出格式：`table`（預設）或 `json` |
+
+## 注意事項
+
+- 跨市場對比（如美股 vs 港股）時，建議指定 `--currency` 統一單位
+- PE、PB、PS 為 TTM（過去 12 個月）數據
+- ROE 為最新報告期數據

--- a/docs/zh-HK/docs/cli/market-data/rank.md
+++ b/docs/zh-HK/docs/cli/market-data/rank.md
@@ -1,0 +1,88 @@
+---
+title: 'rank'
+sidebar_label: 'rank'
+sidebar_position: 20
+---
+
+# longbridge rank
+
+LB 人氣排行榜，綜合交易熱度、社群討論、關注度等多維指標。不傳 `--key` 時列出所有排行榜分類；傳入 `--key` 時顯示該榜單的股票排名。
+
+<QuotePermission command="rank" />
+
+## 基本用法
+
+```bash
+longbridge rank
+```
+
+```
+Rank Categories
+
+Total Heat:
+  ib_hot_all-us   美股
+  ib_hot_all-hk   港股
+  ib_hot_all-cn   A 股
+
+Heat Rising:
+  ib_hot_up-us    美股
+  ib_hot_up-hk    港股
+  ib_hot_up-cn    A 股
+
+Heat Falling:
+  ib_hot_down-us  美股
+  ib_hot_down-hk  港股
+  ib_hot_down-cn  A 股
+```
+
+## 示例
+
+### 查看美股總熱度排行
+
+```bash
+longbridge rank --key ib_hot_all-us
+```
+
+```
+Rank — ib_hot_all-us
+
+| # | symbol  | name    | last_done | chg     | inflow          |
+|---|---------|---------|-----------|---------|-----------------|
+| 1 | MU.US   | 美光科技 | 698.74    | +4.76%  | -347,041,642    |
+| 2 | NVDA.US | 英偉達   | 131.80    | +3.21%  | +1,234,567,890  |
+| 3 | AAPL.US | 蘋果     | 205.10    | -0.42%  | +567,890,123    |
+```
+
+### 查看港股總熱度排行
+
+```bash
+longbridge rank --key ib_hot_all-hk
+```
+
+### 查看熱度上升榜（前 20）
+
+```bash
+longbridge rank --key ib_hot_up-us --count 20
+```
+
+### 查看所有分類
+
+```bash
+longbridge rank
+```
+
+不傳 `--key` 時列出所有可用的排行榜 key，可直接複製用於 `--key` 參數。
+
+## 參數
+
+| 參數 | 說明 |
+|------|------|
+| `--key` | 排行榜 key（從無參數調用的輸出中獲取） |
+| `--market` | 市場篩選，用於無參數時的分類清單（預設：`US`） |
+| `--count` | 返回筆數（預設：20） |
+| `--format` | 輸出格式：`table`（預設）或 `json` |
+
+## 注意事項
+
+- 人氣排行綜合考量交易熱度、社群討論量、關注數等多維指標，與純價格漲跌排行不同
+- `inflow` 為當日資金淨流入（正值流入，負值流出）

--- a/docs/zh-HK/docs/cli/market-data/top-movers.md
+++ b/docs/zh-HK/docs/cli/market-data/top-movers.md
@@ -1,0 +1,72 @@
+---
+title: 'top-movers'
+sidebar_label: 'top-movers'
+sidebar_position: 19
+---
+
+# longbridge top-movers
+
+價格波動超過近 20 日標準差的異動股票。系統自動關聯相關新聞解讀異動原因，與 `anomaly` 命令（純技術信號）不同，`top-movers` 側重於有新聞背景的價格波動。
+
+<QuotePermission command="top-movers" />
+
+## 基本用法
+
+```bash
+longbridge top-movers
+```
+
+```
+Top Movers — US
+
+TSLA  特斯拉  -3.88%  [汽車製造商]
+  Alert: 波動超 20 日均值
+  Related news: "Tesla Q1 deliveries miss estimates..."
+
+NVDA  英偉達  +4.21%  [半導體廠商]
+  Alert: 波動超 20 日均值
+  Related news: "NVIDIA announces next-gen GPU architecture..."
+```
+
+## 示例
+
+### 查看美股異動
+
+```bash
+longbridge top-movers
+longbridge top-movers --market US
+```
+
+預設顯示美股異動股票，按熱度排序。
+
+### 查看港股異動
+
+```bash
+longbridge top-movers --market HK
+```
+
+### 按時間排序並增加返回數量
+
+```bash
+longbridge top-movers --market US --sort time --count 50
+```
+
+### 按漲跌幅排序
+
+```bash
+longbridge top-movers --market US --sort change
+```
+
+## 參數
+
+| 參數 | 說明 |
+|------|------|
+| `--market` | 市場：`HK`、`US`、`CN`、`SG`（預設：`US`） |
+| `--sort` | 排序方式：`hot`（熱度，預設）、`time`（時間）、`change`（漲跌幅） |
+| `--count` | 返回筆數（預設：20） |
+| `--format` | 輸出格式：`table`（預設）或 `json` |
+
+## 注意事項
+
+- `top-movers` 關聯新聞，適合理解異動背景；`anomaly` 側重純技術信號
+- 波動判斷基於近 20 日歷史波動標準差

--- a/docs/zh-HK/docs/cli/research/screener.md
+++ b/docs/zh-HK/docs/cli/research/screener.md
@@ -1,0 +1,116 @@
+---
+title: 'screener'
+sidebar_label: 'screener'
+sidebar_position: 4
+---
+
+# longbridge screener
+
+股票篩選工具，透過預設策略或自訂指標條件篩選股票。
+
+## 基本用法
+
+```bash
+longbridge screener strategies
+```
+
+```
+Recommended Strategies
+
+| id | name              | market | description                   |
+|----|-------------------|--------|-------------------------------|
+| 1  | 高股息防禦型       | HK     | 股息率 > 5%，PE < 15          |
+| 2  | 成長加速型         | US     | 營收增速 > 30%，ROE > 20%     |
+| 42 | 低估值藍籌         | HK     | PB < 1.5，市值 > 100 億港元   |
+```
+
+## 示例
+
+### 工作流 A — 使用預設策略
+
+**第一步：取得策略清單**
+
+```bash
+longbridge screener strategies
+```
+
+**第二步：查看策略篩選條件**
+
+```bash
+longbridge screener strategies --id 42
+```
+
+```
+Strategy #42: 低估值藍籌
+
+Filters:
+  filter_pb: 0 ~ 1.5
+  filter_marketcap: 100 ~ (unlimited)
+  filter_divyld: 2 ~ (unlimited)
+```
+
+**第三步：執行篩選**
+
+```bash
+longbridge screener search --strategy-id 42
+```
+
+### 工作流 B — 自訂條件
+
+**第一步：查看可用指標**
+
+```bash
+longbridge screener indicators
+```
+
+```
+Available Indicators
+
+Valuation:
+  filter_pe          市盈率 (PE)
+  filter_pb          市淨率 (PB)
+  filter_ps          市銷率 (PS)
+  filter_marketcap   市值（億）
+  filter_divyld      股息率 (%)
+
+Growth:
+  filter_rev_growth  營收增速 (%)
+  filter_roe         淨資產收益率 (%)
+  ...
+```
+
+**第二步：執行自訂篩選**
+
+```bash
+longbridge screener search --market HK --filter filter_marketcap:100:1000 --filter filter_divyld:3:
+```
+
+指標格式：`<key>:<min>:<max>`，省略 `min` 或 `max` 表示不限下/上限。
+
+### 查看我的策略
+
+```bash
+longbridge screener strategies --mine
+```
+
+顯示已儲存的自訂策略清單。
+
+## 子命令
+
+| 子命令 | 說明 |
+|--------|------|
+| `strategies` | 列出推薦策略（加 `--mine` 顯示自訂策略） |
+| `strategies --id <id>` | 查看特定策略的篩選條件 |
+| `search` | 執行篩選（`--strategy-id` 或 `--filter`） |
+| `indicators` | 列出所有可用篩選指標 |
+
+## 參數
+
+| 參數 | 說明 |
+|------|------|
+| `--mine` | 顯示我儲存的策略（配合 `strategies` 使用） |
+| `--id` | 查看指定策略的條件（配合 `strategies` 使用） |
+| `--strategy-id` | 執行指定策略的篩選（配合 `search` 使用） |
+| `--market` | 篩選市場：`HK`、`US`、`CN`、`SG`（配合 `search` 使用） |
+| `--filter` | 自訂篩選條件，格式 `<key>:<min>:<max>`，可多次使用 |
+| `--format` | 輸出格式：`table`（預設）或 `json` |

--- a/docs/zh-HK/docs/cli/research/shareholder.md
+++ b/docs/zh-HK/docs/cli/research/shareholder.md
@@ -34,3 +34,50 @@ longbridge shareholder TSLA.US --format json
 ```
 
 按持股比例列出最大股東，包括機構投資者和個人內部人士。
+
+### 查看前 20 大股東（--top）
+
+```bash
+longbridge shareholder AAPL.US --top
+```
+
+```
+Top 20 Shareholders — AAPL.US
+
+Period: Latest
+
+| shareholder                    | type        | % shares | chg shares | filing_date |
+|--------------------------------|-------------|----------|------------|-------------|
+| The Vanguard Group, Inc.       | Institution | 9.71%    | +0.01%     | 2025/12/31  |
+| BlackRock, Inc.                | Institution | 7.75%    | -0.06%     | 2026/03/31  |
+| ...
+
+Use --object-id <id> to view holding detail for a specific shareholder.
+```
+
+`--top` 模式覆蓋多個報告期，包含機構、個人及內部人士，並顯示股東類型（Institution / Individual / Insider）。
+
+### 查看特定股東持股詳情（--object-id）
+
+```bash
+longbridge shareholder AAPL.US --object-id 148057
+```
+
+```
+Shareholder Detail: The Vanguard Group, Inc.
+
+Trading History:
+
+Period: Past 1 Year
+  accum_buy: 0.00  accum_sell: 0.00
+```
+
+`--object-id` 接受 `--top` 輸出中的股東 ID，返回該股東歷史持倉變化和買賣記錄。
+
+## 參數
+
+| 參數 | 說明 |
+|------|------|
+| `--top` | 顯示前 20 大股東，含機構和個人，跨多個報告期 |
+| `--object-id` | 查看特定股東持倉詳情（ID 從 `--top` 輸出獲取） |
+| `--format` | 輸出格式：`table`（預設）或 `json` |


### PR DESCRIPTION
## Summary

- **Updated** `short-positions` (all 3 locales): adds HK market support (HKEX daily data), new `--trades` flag for daily short sale volume vs position balance
- **Updated** `shareholder` (all 3 locales): adds `--top` flag for top-20 shareholders across periods, and `--object-id` for shareholder holding detail
- **Created** `short-trades` (derivatives, sidebar_position: 4): standalone command for daily short sale volume (US FINRA/Nasdaq + HK HKEX)
- **Created** `compare` (fundamentals, sidebar_position: 18): cross-stock valuation comparison (PE/PB/PS/market cap/ROE) with auto peer selection
- **Created** `top-movers` (market-data, sidebar_position: 19): stocks exceeding 20-day volatility with linked news context
- **Created** `screener` (research, sidebar_position: 4): stock screener with preset strategies, custom filter conditions, and indicator listing
- **Created** `rank` (market-data, sidebar_position: 20): LB popularity rankings with composite heat score

All files created for zh-CN, zh-HK (Traditional Chinese), and en locales.

## Test plan

- [ ] Verify sidebar navigation renders correctly for all new files
- [ ] Check `short-positions` HK examples display correctly
- [ ] Verify `--trades` flag documentation is clear for both US and HK outputs
- [ ] Confirm `screener` two-workflow pattern (A: preset strategy, B: custom filter) is easy to follow
- [ ] Check `rank` no-args vs `--key` usage pattern is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)